### PR TITLE
chore: add AWS credentials secret reference to the controller

### DIFF
--- a/.kubernetes/manifests.yaml
+++ b/.kubernetes/manifests.yaml
@@ -503,6 +503,19 @@ spec:
         - --leader-elect
         command:
         - /manager
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              key: access-key-id
+              name: aws-credentials
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: secret-access-key
+              name: aws-credentials
+        - name: AWS_REGION
+          value: us-east-1
         image: tfgco/provider-crossplane:latest
         livenessProbe:
           httpGet:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -11,5 +11,7 @@ configMapGenerator:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
+- name: controller
+  newName: tfgco/provider-crossplane
 - name: manager
   newName: tfgco/provider-crossplane

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -33,6 +33,19 @@ spec:
         - --leader-elect
         image: controller:latest
         name: manager
+        env:
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: aws-credentials
+                key: access-key-id
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: aws-credentials
+                key: secret-access-key
+          - name: AWS_REGION
+            value: us-east-1
         securityContext:
           allowPrivilegeEscalation: false
         livenessProbe:


### PR DESCRIPTION
The purpose of this PR is to add the reference to the Secret that holds the AWS credentials in the manager deployment file