### PR TITLE
fix: add missing permissions to the clustermesh controller

### DIFF
--- a/.kubernetes/manifests.yaml
+++ b/.kubernetes/manifests.yaml
@@ -276,6 +276,14 @@ metadata:
   name: provider-crossplane-manager-role
 rules:
 - apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - clustermesh.infrastructure.wildlife.io
   resources:
   - clustermeshes
@@ -320,6 +328,15 @@ rules:
   - list
   - patch
   - update
+  - watch
+- apiGroups:
+  - ec2.aws.crossplane.io
+  resources:
+  - vpcpeeringconnections
+  verbs:
+  - create
+  - delete
+  - list
   - watch
 - apiGroups:
   - infrastructure.cluster.x-k8s.io

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -6,6 +6,14 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - clustermesh.infrastructure.wildlife.io
   resources:
   - clustermeshes
@@ -50,6 +58,15 @@ rules:
   - list
   - patch
   - update
+  - watch
+- apiGroups:
+  - ec2.aws.crossplane.io
+  resources:
+  - vpcpeeringconnections
+  verbs:
+  - create
+  - delete
+  - list
   - watch
 - apiGroups:
   - infrastructure.cluster.x-k8s.io

--- a/controllers/clustermesh/clustermesh_controller.go
+++ b/controllers/clustermesh/clustermesh_controller.go
@@ -49,6 +49,8 @@ type ClusterMeshReconciler struct {
 	ReconcilePeeringsFactory   func(r *ClusterMeshReconciler, ctx context.Context, clustermesh *clustermeshv1beta1.ClusterMesh) (ctrl.Result, error)
 }
 
+//+kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters,verbs=get;list;watch
+//+kubebuilder:rbac:groups=ec2.aws.crossplane.io,resources=vpcpeeringconnections,verbs=list;watch;create;delete
 //+kubebuilder:rbac:groups=clustermesh.infrastructure.wildlife.io,resources=clustermeshes,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=clustermesh.infrastructure.wildlife.io,resources=clustermeshes/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=clustermesh.infrastructure.wildlife.io,resources=clustermeshes/finalizers,verbs=update


### PR DESCRIPTION
This MR is to add the missing permissions to the clustermesh controller in order to manage the vpcpeeringconnections.ec2.aws.crossplane.io and clusters.cluster.x-k8s.io