### PR TITLE
feat(vpcpeering): use custom api group for vpcpeering

### DIFF
--- a/controllers/clustermesh/clustermesh_controller.go
+++ b/controllers/clustermesh/clustermesh_controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"time"
 
+	wildlifecrossec2v1alphav1 "github.com/topfreegames/crossplane-provider-aws/apis/ec2/manualv1alpha1"
 	kcontrolplanev1alpha1 "github.com/topfreegames/kubernetes-kops-operator/apis/controlplane/v1alpha1"
 	"github.com/topfreegames/kubernetes-kops-operator/pkg/kops"
 	clustermeshv1beta1 "github.com/topfreegames/provider-crossplane/apis/clustermesh/v1alpha1"
@@ -32,7 +33,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/barkimedes/go-deepcopy"
-	crossec2v1alphav1 "github.com/crossplane-contrib/provider-aws/apis/ec2/v1alpha1"
 	crossplanev1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
@@ -53,9 +53,10 @@ import (
 )
 
 var (
-	requeue1min   = ctrl.Result{RequeueAfter: 1 * time.Minute}
-	resultDefault = ctrl.Result{RequeueAfter: 1 * time.Hour}
-	resultError   = ctrl.Result{RequeueAfter: 30 * time.Minute}
+	requeue1min                    = ctrl.Result{RequeueAfter: 1 * time.Minute}
+	resultDefault                  = ctrl.Result{RequeueAfter: 1 * time.Hour}
+	resultError                    = ctrl.Result{RequeueAfter: 30 * time.Minute}
+	vpcPeeringConnectionAPIVersion = "ec2.aws.wildlife.io/v1alpha1"
 )
 
 // ClusterMeshReconciler reconciles a ClusterMesh object
@@ -348,7 +349,7 @@ func ReconcilePeerings(r *ClusterMeshReconciler, ctx context.Context, clustermes
 }
 
 func ReconcileRoutes(r *ClusterMeshReconciler, ctx context.Context, clSpec *clustermeshv1beta1.ClusterSpec) (ctrl.Result, error) {
-	vpcPeeringConnections := &crossec2v1alphav1.VPCPeeringConnectionList{}
+	vpcPeeringConnections := &wildlifecrossec2v1alphav1.VPCPeeringConnectionList{}
 	err := r.Client.List(ctx, vpcPeeringConnections)
 	if err != nil {
 		return resultError, err
@@ -377,7 +378,7 @@ func ReconcileRoutes(r *ClusterMeshReconciler, ctx context.Context, clSpec *clus
 	return resultDefault, nil
 }
 
-func manageCrossplaneRoutes(r *ClusterMeshReconciler, ctx context.Context, clusterCIDR string, vpcPeeringConnection crossec2v1alphav1.VPCPeeringConnection, clSpec *clustermeshv1beta1.ClusterSpec) error {
+func manageCrossplaneRoutes(r *ClusterMeshReconciler, ctx context.Context, clusterCIDR string, vpcPeeringConnection wildlifecrossec2v1alphav1.VPCPeeringConnection, clSpec *clustermeshv1beta1.ClusterSpec) error {
 	vpcPeeringConnectionID := vpcPeeringConnection.ObjectMeta.Annotations["crossplane.io/external-name"]
 	isRouteCreated, err := crossplane.IsRouteToVpcPeeringAlreadyCreated(ctx, clusterCIDR, vpcPeeringConnectionID, clSpec.RouteTableIDs, r.Client)
 	if err != nil {

--- a/controllers/clustermesh/clustermesh_controller_test.go
+++ b/controllers/clustermesh/clustermesh_controller_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"testing"
 
+	wildlifecrossec2v1alphav1 "github.com/topfreegames/crossplane-provider-aws/apis/ec2/manualv1alpha1"
+
 	kcontrolplanev1alpha1 "github.com/topfreegames/kubernetes-kops-operator/apis/controlplane/v1alpha1"
 	clustermeshv1beta1 "github.com/topfreegames/provider-crossplane/apis/clustermesh/v1alpha1"
 	securitygroupv1alpha1 "github.com/topfreegames/provider-crossplane/apis/securitygroup/v1alpha1"
@@ -182,7 +184,7 @@ func TestClusterMeshReconciler(t *testing.T) {
 	err = securitygroupv1alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = crossec2v1alpha1.AddToScheme(scheme.Scheme)
+	err = wildlifecrossec2v1alphav1.SchemeBuilder.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	for _, tc := range testCases {
@@ -1189,9 +1191,9 @@ func TestReconcilePeerings(t *testing.T) {
 		{
 			description: "should not create a vpcpeering when it already exists",
 			k8sObjects: []client.Object{
-				&crossec2v1alpha1.VPCPeeringConnection{
+				&wildlifecrossec2v1alphav1.VPCPeeringConnection{
 					TypeMeta: metav1.TypeMeta{
-						APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+						APIVersion: vpcPeeringConnectionAPIVersion,
 						Kind:       "VPCPeeringConnection",
 					},
 					ObjectMeta: metav1.ObjectMeta{
@@ -1222,7 +1224,7 @@ func TestReconcilePeerings(t *testing.T) {
 					CrossplanePeeringRef: []*corev1.ObjectReference{
 						{
 							Name:       "A-B",
-							APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+							APIVersion: "ec2.aws.wildife.io/v1alpha1",
 							Kind:       "VPCPeeringConnection",
 						},
 					},
@@ -1233,9 +1235,9 @@ func TestReconcilePeerings(t *testing.T) {
 		{
 			description: "should not create a vpcpeering when it already exists inverted",
 			k8sObjects: []client.Object{
-				&crossec2v1alpha1.VPCPeeringConnection{
+				&wildlifecrossec2v1alphav1.VPCPeeringConnection{
 					TypeMeta: metav1.TypeMeta{
-						APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+						APIVersion: vpcPeeringConnectionAPIVersion,
 						Kind:       "VPCPeeringConnection",
 					},
 					ObjectMeta: metav1.ObjectMeta{
@@ -1266,7 +1268,7 @@ func TestReconcilePeerings(t *testing.T) {
 					CrossplanePeeringRef: []*corev1.ObjectReference{
 						{
 							Name:       "B-A",
-							APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+							APIVersion: vpcPeeringConnectionAPIVersion,
 							Kind:       "VPCPeeringConnection",
 						},
 					},
@@ -1277,9 +1279,9 @@ func TestReconcilePeerings(t *testing.T) {
 		{
 			description: "should create correctly with different spec orders",
 			k8sObjects: []client.Object{
-				&crossec2v1alpha1.VPCPeeringConnection{
+				&wildlifecrossec2v1alphav1.VPCPeeringConnection{
 					TypeMeta: metav1.TypeMeta{
-						APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+						APIVersion: vpcPeeringConnectionAPIVersion,
 						Kind:       "VPCPeeringConnection",
 					},
 					ObjectMeta: metav1.ObjectMeta{
@@ -1310,7 +1312,7 @@ func TestReconcilePeerings(t *testing.T) {
 					CrossplanePeeringRef: []*corev1.ObjectReference{
 						{
 							Name:       "A-B",
-							APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+							APIVersion: vpcPeeringConnectionAPIVersion,
 							Kind:       "VPCPeeringConnection",
 						},
 					},
@@ -1321,9 +1323,9 @@ func TestReconcilePeerings(t *testing.T) {
 		{
 			description: "should remove vpcpeerings related with cluster C",
 			k8sObjects: []client.Object{
-				&crossec2v1alpha1.VPCPeeringConnection{
+				&wildlifecrossec2v1alphav1.VPCPeeringConnection{
 					TypeMeta: metav1.TypeMeta{
-						APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+						APIVersion: vpcPeeringConnectionAPIVersion,
 						Kind:       "VPCPeeringConnection",
 					},
 					ObjectMeta: metav1.ObjectMeta{
@@ -1335,9 +1337,9 @@ func TestReconcilePeerings(t *testing.T) {
 						},
 					},
 				},
-				&crossec2v1alpha1.VPCPeeringConnection{
+				&wildlifecrossec2v1alphav1.VPCPeeringConnection{
 					TypeMeta: metav1.TypeMeta{
-						APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+						APIVersion: vpcPeeringConnectionAPIVersion,
 						Kind:       "VPCPeeringConnection",
 					},
 					ObjectMeta: metav1.ObjectMeta{
@@ -1349,9 +1351,9 @@ func TestReconcilePeerings(t *testing.T) {
 						},
 					},
 				},
-				&crossec2v1alpha1.VPCPeeringConnection{
+				&wildlifecrossec2v1alphav1.VPCPeeringConnection{
 					TypeMeta: metav1.TypeMeta{
-						APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+						APIVersion: vpcPeeringConnectionAPIVersion,
 						Kind:       "VPCPeeringConnection",
 					},
 					ObjectMeta: metav1.ObjectMeta{
@@ -1382,17 +1384,17 @@ func TestReconcilePeerings(t *testing.T) {
 					CrossplanePeeringRef: []*corev1.ObjectReference{
 						{
 							Name:       "A-B",
-							APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+							APIVersion: vpcPeeringConnectionAPIVersion,
 							Kind:       "VPCPeeringConnection",
 						},
 						{
 							Name:       "A-C",
-							APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+							APIVersion: vpcPeeringConnectionAPIVersion,
 							Kind:       "VPCPeeringConnection",
 						},
 						{
 							Name:       "B-C",
-							APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+							APIVersion: vpcPeeringConnectionAPIVersion,
 							Kind:       "VPCPeeringConnection",
 						},
 					},
@@ -1404,9 +1406,9 @@ func TestReconcilePeerings(t *testing.T) {
 		{
 			description: "should remove last vpcpeering of the clustermesh",
 			k8sObjects: []client.Object{
-				&crossec2v1alpha1.VPCPeeringConnection{
+				&wildlifecrossec2v1alphav1.VPCPeeringConnection{
 					TypeMeta: metav1.TypeMeta{
-						APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+						APIVersion: vpcPeeringConnectionAPIVersion,
 						Kind:       "VPCPeeringConnection",
 					},
 					ObjectMeta: metav1.ObjectMeta{
@@ -1434,7 +1436,7 @@ func TestReconcilePeerings(t *testing.T) {
 					CrossplanePeeringRef: []*corev1.ObjectReference{
 						{
 							Name:       "A-B",
-							APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+							APIVersion: vpcPeeringConnectionAPIVersion,
 							Kind:       "VPCPeeringConnection",
 						},
 					},
@@ -1444,7 +1446,7 @@ func TestReconcilePeerings(t *testing.T) {
 		},
 	}
 
-	err := crossec2v1alpha1.AddToScheme(scheme.Scheme)
+	err := wildlifecrossec2v1alphav1.SchemeBuilder.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = clustermeshv1beta1.AddToScheme(scheme.Scheme)
@@ -1466,7 +1468,7 @@ func TestReconcilePeerings(t *testing.T) {
 
 			_ = ReconcilePeerings(reconciler, ctx, tc.clustermesh)
 			for _, vpcPeeringConnectionName := range tc.expectedVpcPeeringConnections {
-				vpcPeeringConnection := &crossec2v1alpha1.VPCPeeringConnection{}
+				vpcPeeringConnection := &wildlifecrossec2v1alphav1.VPCPeeringConnection{}
 				key := client.ObjectKey{
 					Name: vpcPeeringConnectionName,
 				}
@@ -1475,7 +1477,7 @@ func TestReconcilePeerings(t *testing.T) {
 			}
 
 			for _, vpcPeeringConnectionName := range tc.shouldBeDeletedVpcPeeringConnections {
-				vpcPeeringConnection := &crossec2v1alpha1.VPCPeeringConnection{}
+				vpcPeeringConnection := &wildlifecrossec2v1alphav1.VPCPeeringConnection{}
 				key := client.ObjectKey{
 					Name: vpcPeeringConnectionName,
 				}
@@ -1491,9 +1493,9 @@ func TestReconcileRoutes(t *testing.T) {
 	RegisterFailHandler(Fail)
 	g := NewWithT(t)
 
-	vpcPeeringConnection := crossec2v1alpha1.VPCPeeringConnection{
+	vpcPeeringConnection := wildlifecrossec2v1alphav1.VPCPeeringConnection{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+			APIVersion: vpcPeeringConnectionAPIVersion,
 			Kind:       "VPCPeeringConnection",
 		},
 		ObjectMeta: metav1.ObjectMeta{
@@ -1502,15 +1504,15 @@ func TestReconcileRoutes(t *testing.T) {
 				"crossplane.io/external-name": "pcx-xxxx",
 			},
 		},
-		Status: crossec2v1alpha1.VPCPeeringConnectionStatus{
+		Status: wildlifecrossec2v1alphav1.VPCPeeringConnectionStatus{
 			ResourceStatus: v1.ResourceStatus{
 				ConditionedStatus: *v1.NewConditionedStatus(v1.Available(), v1.ReconcileSuccess()),
 			},
-			AtProvider: crossec2v1alpha1.VPCPeeringConnectionObservation{
-				AccepterVPCInfo: &crossec2v1alpha1.VPCPeeringConnectionVPCInfo{
+			AtProvider: wildlifecrossec2v1alphav1.VPCPeeringConnectionObservation{
+				AccepterVPCInfo: &wildlifecrossec2v1alphav1.VPCPeeringConnectionVPCInfo{
 					CIDRBlock: aws.String("aaaaa"),
 				},
-				RequesterVPCInfo: &crossec2v1alpha1.VPCPeeringConnectionVPCInfo{
+				RequesterVPCInfo: &wildlifecrossec2v1alphav1.VPCPeeringConnectionVPCInfo{
 					CIDRBlock: aws.String("bbbbb"),
 				},
 			},
@@ -1560,15 +1562,15 @@ func TestReconcileRoutes(t *testing.T) {
 		{
 			description: "should not create routes and return without error if vpcPeering is not ready",
 			k8sObjects: []client.Object{
-				&crossec2v1alpha1.VPCPeeringConnection{
+				&wildlifecrossec2v1alphav1.VPCPeeringConnection{
 					TypeMeta: metav1.TypeMeta{
-						APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+						APIVersion: vpcPeeringConnectionAPIVersion,
 						Kind:       "VPCPeeringConnection",
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "a-b",
 					},
-					Status: crossec2v1alpha1.VPCPeeringConnectionStatus{
+					Status: wildlifecrossec2v1alphav1.VPCPeeringConnectionStatus{
 						ResourceStatus: v1.ResourceStatus{
 							ConditionedStatus: *v1.NewConditionedStatus(v1.Unavailable()),
 						},
@@ -1590,9 +1592,9 @@ func TestReconcileRoutes(t *testing.T) {
 		{
 			description: "should not create routes if cluster don't belong to any vpcPeering",
 			k8sObjects: []client.Object{
-				&crossec2v1alpha1.VPCPeeringConnection{
+				&wildlifecrossec2v1alphav1.VPCPeeringConnection{
 					TypeMeta: metav1.TypeMeta{
-						APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+						APIVersion: vpcPeeringConnectionAPIVersion,
 						Kind:       "VPCPeeringConnection",
 					},
 					ObjectMeta: metav1.ObjectMeta{
@@ -1601,15 +1603,15 @@ func TestReconcileRoutes(t *testing.T) {
 							"crossplane.io/external-name": "pcx-xxxx",
 						},
 					},
-					Status: crossec2v1alpha1.VPCPeeringConnectionStatus{
+					Status: wildlifecrossec2v1alphav1.VPCPeeringConnectionStatus{
 						ResourceStatus: v1.ResourceStatus{
 							ConditionedStatus: *v1.NewConditionedStatus(v1.Available()),
 						},
-						AtProvider: crossec2v1alpha1.VPCPeeringConnectionObservation{
-							AccepterVPCInfo: &crossec2v1alpha1.VPCPeeringConnectionVPCInfo{
+						AtProvider: wildlifecrossec2v1alphav1.VPCPeeringConnectionObservation{
+							AccepterVPCInfo: &wildlifecrossec2v1alphav1.VPCPeeringConnectionVPCInfo{
 								CIDRBlock: aws.String("ccccc"),
 							},
-							RequesterVPCInfo: &crossec2v1alpha1.VPCPeeringConnectionVPCInfo{
+							RequesterVPCInfo: &wildlifecrossec2v1alphav1.VPCPeeringConnectionVPCInfo{
 								CIDRBlock: aws.String("bbbbb"),
 							},
 						},
@@ -1667,7 +1669,10 @@ func TestReconcileRoutes(t *testing.T) {
 		},
 	}
 
-	err := crossec2v1alpha1.AddToScheme(scheme.Scheme)
+	err := wildlifecrossec2v1alphav1.SchemeBuilder.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = crossec2v1alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = clustermeshv1beta1.AddToScheme(scheme.Scheme)
@@ -1849,7 +1854,7 @@ func TestReconcileSecurityGroups(t *testing.T) {
 			},
 		},
 	}
-	err := crossec2v1alpha1.AddToScheme(scheme.Scheme)
+	err := wildlifecrossec2v1alphav1.SchemeBuilder.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = crossec2v1beta1.SchemeBuilder.AddToScheme(scheme.Scheme)
@@ -2037,9 +2042,9 @@ func TestValidateClusterMesh(t *testing.T) {
 		},
 	}
 
-	vpcPeeringConnection := &crossec2v1alpha1.VPCPeeringConnection{
+	vpcPeeringConnection := &wildlifecrossec2v1alphav1.VPCPeeringConnection{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+			APIVersion: vpcPeeringConnectionAPIVersion,
 			Kind:       "VPCPeeringConnection",
 		},
 		ObjectMeta: metav1.ObjectMeta{
@@ -2052,7 +2057,7 @@ func TestValidateClusterMesh(t *testing.T) {
 				},
 			},
 		},
-		Status: crossec2v1alpha1.VPCPeeringConnectionStatus{
+		Status: wildlifecrossec2v1alphav1.VPCPeeringConnectionStatus{
 			ResourceStatus: v1.ResourceStatus{
 				ConditionedStatus: *v1.NewConditionedStatus(v1.Available(), v1.ReconcileSuccess()),
 			},
@@ -2060,7 +2065,7 @@ func TestValidateClusterMesh(t *testing.T) {
 	}
 
 	vpcPeeringConnectionNotReady := vpcPeeringConnection.DeepCopy()
-	vpcPeeringConnectionNotReady.Status = crossec2v1alpha1.VPCPeeringConnectionStatus{
+	vpcPeeringConnectionNotReady.Status = wildlifecrossec2v1alphav1.VPCPeeringConnectionStatus{
 		ResourceStatus: v1.ResourceStatus{
 			ConditionedStatus: *v1.NewConditionedStatus(v1.Unavailable(), v1.ReconcileError(fmt.Errorf("reconcile error"))),
 		},
@@ -2075,7 +2080,7 @@ func TestValidateClusterMesh(t *testing.T) {
 			Name: "rt-xxxx-pcx-xxxx",
 			OwnerReferences: []metav1.OwnerReference{
 				{
-					APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+					APIVersion: vpcPeeringConnectionAPIVersion,
 					Kind:       "VPCPeeringConnection",
 					Name:       "vpc-a-b",
 				},
@@ -2097,7 +2102,7 @@ func TestValidateClusterMesh(t *testing.T) {
 			Name: "rt-xxxx-pcx-zzzzz",
 			OwnerReferences: []metav1.OwnerReference{
 				{
-					APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+					APIVersion: vpcPeeringConnectionAPIVersion,
 					Kind:       "VPCPeeringConnection",
 					Name:       "vpc-a-b",
 				},
@@ -2206,10 +2211,10 @@ func TestValidateClusterMesh(t *testing.T) {
 		},
 	}
 
-	err := crossec2v1alpha1.AddToScheme(scheme.Scheme)
+	err := wildlifecrossec2v1alphav1.SchemeBuilder.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = crossec2v1beta1.SchemeBuilder.AddToScheme(scheme.Scheme)
+	err = crossec2v1alpha1.SchemeBuilder.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = clustermeshv1beta1.AddToScheme(scheme.Scheme)

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,9 @@ require (
 	github.com/onsi/ginkgo/v2 v2.1.4
 	github.com/onsi/gomega v1.19.0
 	github.com/pkg/errors v0.9.1
+	github.com/topfreegames/crossplane-provider-aws v0.27.0-vpcpeering-only
 	github.com/topfreegames/kubernetes-kops-operator v0.0.8-alpha
+	go.uber.org/zap v1.19.1
 	k8s.io/api v0.24.0
 	k8s.io/apimachinery v0.24.0
 	k8s.io/client-go v0.24.0
@@ -132,7 +134,6 @@ require (
 	go.opencensus.io v0.23.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
-	go.uber.org/zap v1.19.1 // indirect
 	golang.org/x/crypto v0.0.0-20220214200702-86341886e292 // indirect
 	golang.org/x/net v0.0.0-20220225172249-27dd8689420f // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -744,6 +744,8 @@ github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMT
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
+github.com/topfreegames/crossplane-provider-aws v0.27.0-vpcpeering-only h1:KlcNIDFGMlmD8C6vc6KjWnyv451SRjQhJCYhVu2W5Ss=
+github.com/topfreegames/crossplane-provider-aws v0.27.0-vpcpeering-only/go.mod h1:wB61cKlwsY2S1U7UIMENEE2p3kO1cOlLRcifZXZuR6E=
 github.com/topfreegames/kubernetes-kops-operator v0.0.8-alpha h1:NfAvn709bwzaLcukeUSEvZeBs3lxnh/8/uuZJM7yCnk=
 github.com/topfreegames/kubernetes-kops-operator v0.0.8-alpha/go.mod h1:4fa8z/WyWT4ExWTu/APf5L1qX7hdBu6fgvylhS+LTQE=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"time"
 
+	wildlifecrossec2v1alphav1 "github.com/topfreegames/crossplane-provider-aws/apis/ec2/manualv1alpha1"
 	kcontrolplanev1alpha1 "github.com/topfreegames/kubernetes-kops-operator/apis/controlplane/v1alpha1"
 	kinfrastructurev1alpha1 "github.com/topfreegames/kubernetes-kops-operator/apis/infrastructure/v1alpha1"
 	clustermeshv1alpha1 "github.com/topfreegames/provider-crossplane/apis/clustermesh/v1alpha1"
@@ -60,6 +61,7 @@ func init() {
 	utilruntime.Must(clusterv1beta1.AddToScheme(scheme))
 	utilruntime.Must(clustermeshv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(securitygroupv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(wildlifecrossec2v1alphav1.SchemeBuilder.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
 }
 

--- a/pkg/crossplane/crossplane.go
+++ b/pkg/crossplane/crossplane.go
@@ -24,7 +24,7 @@ import (
 func NewCrossPlaneVPCPeeringConnection(clustermesh *clustermeshv1beta1.ClusterMesh, peeringRequester, peeringAccepter *clustermeshv1beta1.ClusterSpec) *crossec2v1alphav1.VPCPeeringConnection {
 	crossplaneVPCPeeringConnection := &crossec2v1alphav1.VPCPeeringConnection{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+			APIVersion: "ec2.aws.wildlife.io/v1alpha1",
 			Kind:       "VPCPeeringConnection",
 		},
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/crossplane/crossplane_test.go
+++ b/pkg/crossplane/crossplane_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	wildlifecrossec2v1alphav1 "github.com/topfreegames/crossplane-provider-aws/apis/ec2/manualv1alpha1"
 	clmesh "github.com/topfreegames/provider-crossplane/pkg/clustermesh"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -54,7 +55,7 @@ func TestGetOwnedVPCPeeringConnectionsRef(t *testing.T) {
 		{
 			description: "should return vpcpeeringconnections A-B and A-C",
 			vpcPeeringConnections: []client.Object{
-				&crossec2v1alphav1.VPCPeeringConnection{
+				&wildlifecrossec2v1alphav1.VPCPeeringConnection{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "VPCPeeringConnection",
 						APIVersion: "ec2.aws.wildlife.io/v1alpha1",
@@ -71,7 +72,7 @@ func TestGetOwnedVPCPeeringConnectionsRef(t *testing.T) {
 						},
 					},
 				},
-				&crossec2v1alphav1.VPCPeeringConnection{
+				&wildlifecrossec2v1alphav1.VPCPeeringConnection{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "VPCPeeringConnection",
 						APIVersion: "ec2.aws.wildlife.io/v1alpha1",
@@ -110,7 +111,7 @@ func TestGetOwnedVPCPeeringConnectionsRef(t *testing.T) {
 		{
 			description: "should return only vpcpeeringconnections A-B",
 			vpcPeeringConnections: []client.Object{
-				&crossec2v1alphav1.VPCPeeringConnection{
+				&wildlifecrossec2v1alphav1.VPCPeeringConnection{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "VPCPeeringConnection",
 						APIVersion: "ec2.aws.wildlife.io/v1alpha1",
@@ -127,7 +128,7 @@ func TestGetOwnedVPCPeeringConnectionsRef(t *testing.T) {
 						},
 					},
 				},
-				&crossec2v1alphav1.VPCPeeringConnection{
+				&wildlifecrossec2v1alphav1.VPCPeeringConnection{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "VPCPeeringConnection",
 						APIVersion: "ec2.aws.wildlife.io/v1alpha1",
@@ -161,7 +162,7 @@ func TestGetOwnedVPCPeeringConnectionsRef(t *testing.T) {
 	err := clustermeshv1beta1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = crossec2v1alphav1.AddToScheme(scheme.Scheme)
+	err = wildlifecrossec2v1alphav1.SchemeBuilder.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = clusterv1beta1.AddToScheme(scheme.Scheme)
@@ -189,10 +190,10 @@ func TestGetOwnedVPCPeeringConnections(t *testing.T) {
 		},
 	}
 
-	vpcWithOwner := &crossec2v1alphav1.VPCPeeringConnection{
+	vpcWithOwner := &wildlifecrossec2v1alphav1.VPCPeeringConnection{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "VPCPeeringConnection",
-			APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+			APIVersion: "ec2.aws.wildlife.io/v1alpha1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "A-B",
@@ -208,10 +209,10 @@ func TestGetOwnedVPCPeeringConnections(t *testing.T) {
 		},
 	}
 
-	vpc2WithOwner := &crossec2v1alphav1.VPCPeeringConnection{
+	vpc2WithOwner := &wildlifecrossec2v1alphav1.VPCPeeringConnection{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "VPCPeeringConnection",
-			APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+			APIVersion: "ec2.aws.wildlife.io/v1alpha1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "A-C",
@@ -230,7 +231,7 @@ func TestGetOwnedVPCPeeringConnections(t *testing.T) {
 	testCases := []struct {
 		description                        string
 		objects                            []client.Object
-		expectedOwnedVPCPeeringConnections []crossec2v1alphav1.VPCPeeringConnection
+		expectedOwnedVPCPeeringConnections []wildlifecrossec2v1alphav1.VPCPeeringConnection
 	}{
 		{
 			description: "should return vpcpeeringconnections A-B and A-C",
@@ -243,7 +244,7 @@ func TestGetOwnedVPCPeeringConnections(t *testing.T) {
 					},
 				},
 			},
-			expectedOwnedVPCPeeringConnections: []crossec2v1alphav1.VPCPeeringConnection{
+			expectedOwnedVPCPeeringConnections: []wildlifecrossec2v1alphav1.VPCPeeringConnection{
 				*vpcWithOwner,
 				*vpc2WithOwner,
 			},
@@ -252,10 +253,10 @@ func TestGetOwnedVPCPeeringConnections(t *testing.T) {
 			description: "should return only vpcpeeringconnections A-B",
 			objects: []client.Object{
 				vpcWithOwner,
-				&crossec2v1alphav1.VPCPeeringConnection{
+				&wildlifecrossec2v1alphav1.VPCPeeringConnection{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "VPCPeeringConnection",
-						APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+						APIVersion: "ec2.aws.wildlife.io/v1alpha1",
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "A-C",
@@ -270,7 +271,7 @@ func TestGetOwnedVPCPeeringConnections(t *testing.T) {
 					},
 				},
 			},
-			expectedOwnedVPCPeeringConnections: []crossec2v1alphav1.VPCPeeringConnection{
+			expectedOwnedVPCPeeringConnections: []wildlifecrossec2v1alphav1.VPCPeeringConnection{
 				*vpcWithOwner,
 			},
 		},
@@ -431,9 +432,9 @@ func TestGetOwnedRoutes(t *testing.T) {
 		},
 	}
 
-	owner := &crossec2v1alphav1.VPCPeeringConnection{
+	owner := &wildlifecrossec2v1alphav1.VPCPeeringConnection{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+			APIVersion: "ec2.aws.wildlife.io/v1alpha1",
 			Kind:       "VPCPeeringConnection",
 		},
 		ObjectMeta: metav1.ObjectMeta{
@@ -687,7 +688,7 @@ func TestCreateCrossplaneVPCPeeringConnection(t *testing.T) {
 		clustermeshStatus             clustermeshv1beta1.ClusterMeshStatus
 		peeringRequester              *clustermeshv1beta1.ClusterSpec
 		peeringAccepter               *clustermeshv1beta1.ClusterSpec
-		expectedVPCPeeringConnection  *crossec2v1alphav1.VPCPeeringConnection
+		expectedVPCPeeringConnection  *wildlifecrossec2v1alphav1.VPCPeeringConnection
 		expectedVPCPeeringConnections []*corev1.ObjectReference
 	}{
 		{
@@ -705,9 +706,9 @@ func TestCreateCrossplaneVPCPeeringConnection(t *testing.T) {
 				Region: "eu-central-1",
 				VPCID:  "yyy",
 			},
-			expectedVPCPeeringConnection: &crossec2v1alphav1.VPCPeeringConnection{
+			expectedVPCPeeringConnection: &wildlifecrossec2v1alphav1.VPCPeeringConnection{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+					APIVersion: "ec2.aws.wildlife.io/v1alpha1",
 					Kind:       "VPCPeeringConnection",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -722,11 +723,11 @@ func TestCreateCrossplaneVPCPeeringConnection(t *testing.T) {
 					},
 					ResourceVersion: "1",
 				},
-				Spec: crossec2v1alphav1.VPCPeeringConnectionSpec{
-					ForProvider: crossec2v1alphav1.VPCPeeringConnectionParameters{
+				Spec: wildlifecrossec2v1alphav1.VPCPeeringConnectionSpec{
+					ForProvider: wildlifecrossec2v1alphav1.VPCPeeringConnectionParameters{
 						Region:     "us-east-1",
 						PeerRegion: aws.String("eu-central-1"),
-						CustomVPCPeeringConnectionParameters: crossec2v1alphav1.CustomVPCPeeringConnectionParameters{
+						CustomVPCPeeringConnectionParameters: wildlifecrossec2v1alphav1.CustomVPCPeeringConnectionParameters{
 							VPCID:         aws.String("xxx"),
 							PeerVPCID:     aws.String("yyy"),
 							AcceptRequest: true,
@@ -737,7 +738,7 @@ func TestCreateCrossplaneVPCPeeringConnection(t *testing.T) {
 			expectedVPCPeeringConnections: []*corev1.ObjectReference{
 				{
 					Name:       "A-B",
-					APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+					APIVersion: "ec2.aws.wildlife.io/v1alpha1",
 					Kind:       "VPCPeeringConnection",
 				},
 			},
@@ -745,28 +746,28 @@ func TestCreateCrossplaneVPCPeeringConnection(t *testing.T) {
 		{
 			description: "should do nothing when trying to create a vpcPeeringConnection already created",
 			vpcPeeringConnections: []client.Object{
-				&crossec2v1alphav1.VPCPeeringConnection{
+				&wildlifecrossec2v1alphav1.VPCPeeringConnection{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "VPCPeeringConnection",
-						APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+						APIVersion: "ec2.aws.wildlife.io/v1alpha1",
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "A-B",
 					},
 				},
-				&crossec2v1alphav1.VPCPeeringConnection{
+				&wildlifecrossec2v1alphav1.VPCPeeringConnection{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "VPCPeeringConnection",
-						APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+						APIVersion: "ec2.aws.wildlife.io/v1alpha1",
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "A-C",
 					},
 				},
-				&crossec2v1alphav1.VPCPeeringConnection{
+				&wildlifecrossec2v1alphav1.VPCPeeringConnection{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "VPCPeeringConnection",
-						APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+						APIVersion: "ec2.aws.wildlife.io/v1alpha1",
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "B-C",
@@ -777,17 +778,17 @@ func TestCreateCrossplaneVPCPeeringConnection(t *testing.T) {
 				CrossplanePeeringRef: []*corev1.ObjectReference{
 					{
 						Name:       "A-B",
-						APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+						APIVersion: "ec2.aws.wildlife.io/v1alpha1",
 						Kind:       "VPCPeeringConnection",
 					},
 					{
 						Name:       "A-C",
-						APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+						APIVersion: "ec2.aws.wildlife.io/v1alpha1",
 						Kind:       "VPCPeeringConnection",
 					},
 					{
 						Name:       "B-C",
-						APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+						APIVersion: "ec2.aws.wildlife.io/v1alpha1",
 						Kind:       "VPCPeeringConnection",
 					},
 				},
@@ -802,9 +803,9 @@ func TestCreateCrossplaneVPCPeeringConnection(t *testing.T) {
 				Region: "eu-central-1",
 				VPCID:  "yyy",
 			},
-			expectedVPCPeeringConnection: &crossec2v1alphav1.VPCPeeringConnection{
+			expectedVPCPeeringConnection: &wildlifecrossec2v1alphav1.VPCPeeringConnection{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+					APIVersion: "ec2.aws.wildlife.io/v1alpha1",
 					Kind:       "VPCPeeringConnection",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -819,11 +820,11 @@ func TestCreateCrossplaneVPCPeeringConnection(t *testing.T) {
 					},
 					ResourceVersion: "1",
 				},
-				Spec: crossec2v1alphav1.VPCPeeringConnectionSpec{
-					ForProvider: crossec2v1alphav1.VPCPeeringConnectionParameters{
+				Spec: wildlifecrossec2v1alphav1.VPCPeeringConnectionSpec{
+					ForProvider: wildlifecrossec2v1alphav1.VPCPeeringConnectionParameters{
 						Region:     "us-east-1",
 						PeerRegion: aws.String("eu-central-1"),
-						CustomVPCPeeringConnectionParameters: crossec2v1alphav1.CustomVPCPeeringConnectionParameters{
+						CustomVPCPeeringConnectionParameters: wildlifecrossec2v1alphav1.CustomVPCPeeringConnectionParameters{
 							VPCID:         aws.String("xxx"),
 							PeerVPCID:     aws.String("yyy"),
 							AcceptRequest: true,
@@ -834,17 +835,17 @@ func TestCreateCrossplaneVPCPeeringConnection(t *testing.T) {
 			expectedVPCPeeringConnections: []*corev1.ObjectReference{
 				{
 					Name:       "A-B",
-					APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+					APIVersion: vpcPeeringConnectionAPIVersion,
 					Kind:       "VPCPeeringConnection",
 				},
 				{
 					Name:       "A-C",
-					APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+					APIVersion: vpcPeeringConnectionAPIVersion,
 					Kind:       "VPCPeeringConnection",
 				},
 				{
 					Name:       "B-C",
-					APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+					APIVersion: vpcPeeringConnectionAPIVersion,
 					Kind:       "VPCPeeringConnection",
 				},
 			},
@@ -852,19 +853,19 @@ func TestCreateCrossplaneVPCPeeringConnection(t *testing.T) {
 		{
 			description: "should create a new vpcpeeringconnection when some are already created",
 			vpcPeeringConnections: []client.Object{
-				&crossec2v1alphav1.VPCPeeringConnection{
+				&wildlifecrossec2v1alphav1.VPCPeeringConnection{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "VPCPeeringConnection",
-						APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+						APIVersion: vpcPeeringConnectionAPIVersion,
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "A-B",
 					},
 				},
-				&crossec2v1alphav1.VPCPeeringConnection{
+				&wildlifecrossec2v1alphav1.VPCPeeringConnection{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "VPCPeeringConnection",
-						APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+						APIVersion: vpcPeeringConnectionAPIVersion,
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "B-C",
@@ -875,12 +876,12 @@ func TestCreateCrossplaneVPCPeeringConnection(t *testing.T) {
 				CrossplanePeeringRef: []*corev1.ObjectReference{
 					{
 						Name:       "A-B",
-						APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+						APIVersion: vpcPeeringConnectionAPIVersion,
 						Kind:       "VPCPeeringConnection",
 					},
 					{
 						Name:       "B-C",
-						APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+						APIVersion: vpcPeeringConnectionAPIVersion,
 						Kind:       "VPCPeeringConnection",
 					},
 				},
@@ -895,9 +896,9 @@ func TestCreateCrossplaneVPCPeeringConnection(t *testing.T) {
 				Region: "eu-central-1",
 				VPCID:  "yyy",
 			},
-			expectedVPCPeeringConnection: &crossec2v1alphav1.VPCPeeringConnection{
+			expectedVPCPeeringConnection: &wildlifecrossec2v1alphav1.VPCPeeringConnection{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+					APIVersion: vpcPeeringConnectionAPIVersion,
 					Kind:       "VPCPeeringConnection",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -912,11 +913,11 @@ func TestCreateCrossplaneVPCPeeringConnection(t *testing.T) {
 					},
 					ResourceVersion: "1",
 				},
-				Spec: crossec2v1alphav1.VPCPeeringConnectionSpec{
-					ForProvider: crossec2v1alphav1.VPCPeeringConnectionParameters{
+				Spec: wildlifecrossec2v1alphav1.VPCPeeringConnectionSpec{
+					ForProvider: wildlifecrossec2v1alphav1.VPCPeeringConnectionParameters{
 						Region:     "us-east-1",
 						PeerRegion: aws.String("eu-central-1"),
-						CustomVPCPeeringConnectionParameters: crossec2v1alphav1.CustomVPCPeeringConnectionParameters{
+						CustomVPCPeeringConnectionParameters: wildlifecrossec2v1alphav1.CustomVPCPeeringConnectionParameters{
 							VPCID:         aws.String("xxx"),
 							PeerVPCID:     aws.String("yyy"),
 							AcceptRequest: true,
@@ -927,17 +928,17 @@ func TestCreateCrossplaneVPCPeeringConnection(t *testing.T) {
 			expectedVPCPeeringConnections: []*corev1.ObjectReference{
 				{
 					Name:       "A-B",
-					APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+					APIVersion: vpcPeeringConnectionAPIVersion,
 					Kind:       "VPCPeeringConnection",
 				},
 				{
 					Name:       "A-C",
-					APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+					APIVersion: vpcPeeringConnectionAPIVersion,
 					Kind:       "VPCPeeringConnection",
 				},
 				{
 					Name:       "B-C",
-					APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+					APIVersion: vpcPeeringConnectionAPIVersion,
 					Kind:       "VPCPeeringConnection",
 				},
 			},
@@ -962,7 +963,7 @@ func TestCreateCrossplaneVPCPeeringConnection(t *testing.T) {
 			key := client.ObjectKey{
 				Name: fmt.Sprintf("%s-%s", tc.peeringRequester.Name, tc.peeringAccepter.Name),
 			}
-			vpcPeeringConnection := &crossec2v1alphav1.VPCPeeringConnection{}
+			vpcPeeringConnection := &wildlifecrossec2v1alphav1.VPCPeeringConnection{}
 			err = fakeClient.Get(ctx, key, vpcPeeringConnection)
 			g.Expect(err).To(BeNil())
 			g.Expect(vpcPeeringConnection).ToNot(BeNil())
@@ -989,45 +990,45 @@ func TestDeleteCrossplaneVPCPeeringConnection(t *testing.T) {
 					CrossplanePeeringRef: []*corev1.ObjectReference{
 						{
 							Name:       "A-B",
-							APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+							APIVersion: vpcPeeringConnectionAPIVersion,
 							Kind:       "VPCPeeringConnection",
 						},
 						{
 							Name:       "A-C",
-							APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+							APIVersion: vpcPeeringConnectionAPIVersion,
 							Kind:       "VPCPeeringConnection",
 						},
 						{
 							Name:       "B-C",
-							APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+							APIVersion: vpcPeeringConnectionAPIVersion,
 							Kind:       "VPCPeeringConnection",
 						},
 					},
 				},
 			},
 			vpcPeeringConnections: []client.Object{
-				&crossec2v1alphav1.VPCPeeringConnection{
+				&wildlifecrossec2v1alphav1.VPCPeeringConnection{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "VPCPeeringConnection",
-						APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+						APIVersion: vpcPeeringConnectionAPIVersion,
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "A-B",
 					},
 				},
-				&crossec2v1alphav1.VPCPeeringConnection{
+				&wildlifecrossec2v1alphav1.VPCPeeringConnection{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "VPCPeeringConnection",
-						APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+						APIVersion: vpcPeeringConnectionAPIVersion,
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "A-C",
 					},
 				},
-				&crossec2v1alphav1.VPCPeeringConnection{
+				&wildlifecrossec2v1alphav1.VPCPeeringConnection{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "VPCPeeringConnection",
-						APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+						APIVersion: vpcPeeringConnectionAPIVersion,
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "B-C",
@@ -1036,18 +1037,18 @@ func TestDeleteCrossplaneVPCPeeringConnection(t *testing.T) {
 			},
 			vpcPeeringToBeDeleted: &corev1.ObjectReference{
 				Name:       "A-B",
-				APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+				APIVersion: vpcPeeringConnectionAPIVersion,
 				Kind:       "VPCPeeringConnection",
 			},
 			expectedVPCPeeringConnections: []*corev1.ObjectReference{
 				{
 					Name:       "B-C",
-					APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+					APIVersion: vpcPeeringConnectionAPIVersion,
 					Kind:       "VPCPeeringConnection",
 				},
 				{
 					Name:       "A-C",
-					APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+					APIVersion: vpcPeeringConnectionAPIVersion,
 					Kind:       "VPCPeeringConnection",
 				},
 			},
@@ -1062,31 +1063,31 @@ func TestDeleteCrossplaneVPCPeeringConnection(t *testing.T) {
 					CrossplanePeeringRef: []*corev1.ObjectReference{
 						{
 							Name:       "A-C",
-							APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+							APIVersion: vpcPeeringConnectionAPIVersion,
 							Kind:       "VPCPeeringConnection",
 						},
 						{
 							Name:       "B-C",
-							APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+							APIVersion: vpcPeeringConnectionAPIVersion,
 							Kind:       "VPCPeeringConnection",
 						},
 					},
 				},
 			},
 			vpcPeeringConnections: []client.Object{
-				&crossec2v1alphav1.VPCPeeringConnection{
+				&wildlifecrossec2v1alphav1.VPCPeeringConnection{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "VPCPeeringConnection",
-						APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+						APIVersion: vpcPeeringConnectionAPIVersion,
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "A-C",
 					},
 				},
-				&crossec2v1alphav1.VPCPeeringConnection{
+				&wildlifecrossec2v1alphav1.VPCPeeringConnection{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "VPCPeeringConnection",
-						APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+						APIVersion: vpcPeeringConnectionAPIVersion,
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "B-C",
@@ -1095,24 +1096,24 @@ func TestDeleteCrossplaneVPCPeeringConnection(t *testing.T) {
 			},
 			vpcPeeringToBeDeleted: &corev1.ObjectReference{
 				Name:       "A-B",
-				APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+				APIVersion: vpcPeeringConnectionAPIVersion,
 				Kind:       "VPCPeeringConnection",
 			},
 			expectedVPCPeeringConnections: []*corev1.ObjectReference{
 				{
 					Name:       "B-C",
-					APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+					APIVersion: vpcPeeringConnectionAPIVersion,
 					Kind:       "VPCPeeringConnection",
 				},
 				{
 					Name:       "A-C",
-					APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+					APIVersion: vpcPeeringConnectionAPIVersion,
 					Kind:       "VPCPeeringConnection",
 				},
 			},
 		},
 		{
-			description: "should remove A-B VPCPeeringConnection",
+			description: "should remove the only VPCPeeringConnection",
 			clustermesh: &clustermeshv1beta1.ClusterMesh{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-clustermesh",
@@ -1121,17 +1122,17 @@ func TestDeleteCrossplaneVPCPeeringConnection(t *testing.T) {
 					CrossplanePeeringRef: []*corev1.ObjectReference{
 						{
 							Name:       "A-B",
-							APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+							APIVersion: "ec2.aws.wildlife.io/v1alpha1",
 							Kind:       "VPCPeeringConnection",
 						},
 					},
 				},
 			},
 			vpcPeeringConnections: []client.Object{
-				&crossec2v1alphav1.VPCPeeringConnection{
+				&wildlifecrossec2v1alphav1.VPCPeeringConnection{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "VPCPeeringConnection",
-						APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+						APIVersion: "ec2.aws.wildlife.io/v1alpha1",
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "A-B",
@@ -1140,7 +1141,7 @@ func TestDeleteCrossplaneVPCPeeringConnection(t *testing.T) {
 			},
 			vpcPeeringToBeDeleted: &corev1.ObjectReference{
 				Name:       "A-B",
-				APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+				APIVersion: "ec2.aws.wildlife.io/v1alpha1",
 				Kind:       "VPCPeeringConnection",
 			},
 			expectedVPCPeeringConnections: []*corev1.ObjectReference{},
@@ -1150,7 +1151,7 @@ func TestDeleteCrossplaneVPCPeeringConnection(t *testing.T) {
 	RegisterFailHandler(Fail)
 	g := NewWithT(t)
 
-	err := crossec2v1alphav1.AddToScheme(scheme.Scheme)
+	err := wildlifecrossec2v1alphav1.SchemeBuilder.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	for _, tc := range testCases {
@@ -1162,7 +1163,7 @@ func TestDeleteCrossplaneVPCPeeringConnection(t *testing.T) {
 				Name: tc.vpcPeeringToBeDeleted.Name,
 			}
 
-			vpcPeeringConnection := &crossec2v1alphav1.VPCPeeringConnection{}
+			vpcPeeringConnection := &wildlifecrossec2v1alphav1.VPCPeeringConnection{}
 			err = fakeClient.Get(ctx, key, vpcPeeringConnection)
 			g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
 
@@ -1170,7 +1171,7 @@ func TestDeleteCrossplaneVPCPeeringConnection(t *testing.T) {
 				key = client.ObjectKey{
 					Name: expectedVPCPeeringConnectionRef.Name,
 				}
-				expectedVPCPeeringConnection := &crossec2v1alphav1.VPCPeeringConnection{}
+				expectedVPCPeeringConnection := &wildlifecrossec2v1alphav1.VPCPeeringConnection{}
 				err = fakeClient.Get(ctx, key, expectedVPCPeeringConnection)
 				g.Expect(err).To(BeNil())
 			}
@@ -1557,10 +1558,10 @@ func TestIsRouteToVpcPeeringAlreadyCreated(t *testing.T) {
 
 func TestCreateCrossplaneRoute(t *testing.T) {
 
-	vpcPeeringConnection := &crossec2v1alphav1.VPCPeeringConnection{
+	vpcPeeringConnection := &wildlifecrossec2v1alphav1.VPCPeeringConnection{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "VPCPeeringConnection",
-			APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+			APIVersion: "ec2.aws.wildlife.io/v1alpha1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "peering-A-B",

--- a/pkg/crossplane/crossplane_test.go
+++ b/pkg/crossplane/crossplane_test.go
@@ -57,7 +57,7 @@ func TestGetOwnedVPCPeeringConnectionsRef(t *testing.T) {
 				&crossec2v1alphav1.VPCPeeringConnection{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "VPCPeeringConnection",
-						APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+						APIVersion: "ec2.aws.wildlife.io/v1alpha1",
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "A-B",
@@ -74,7 +74,7 @@ func TestGetOwnedVPCPeeringConnectionsRef(t *testing.T) {
 				&crossec2v1alphav1.VPCPeeringConnection{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "VPCPeeringConnection",
-						APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+						APIVersion: "ec2.aws.wildlife.io/v1alpha1",
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "A-C",
@@ -97,12 +97,12 @@ func TestGetOwnedVPCPeeringConnectionsRef(t *testing.T) {
 			expectedOwnedVPCPeeringConnections: []*corev1.ObjectReference{
 				{
 					Name:       "A-B",
-					APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+					APIVersion: "ec2.aws.wildlife.io/v1alpha1",
 					Kind:       "VPCPeeringConnection",
 				},
 				{
 					Name:       "A-C",
-					APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+					APIVersion: "ec2.aws.wildlife.io/v1alpha1",
 					Kind:       "VPCPeeringConnection",
 				},
 			},
@@ -113,7 +113,7 @@ func TestGetOwnedVPCPeeringConnectionsRef(t *testing.T) {
 				&crossec2v1alphav1.VPCPeeringConnection{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "VPCPeeringConnection",
-						APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+						APIVersion: "ec2.aws.wildlife.io/v1alpha1",
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "A-B",
@@ -130,7 +130,7 @@ func TestGetOwnedVPCPeeringConnectionsRef(t *testing.T) {
 				&crossec2v1alphav1.VPCPeeringConnection{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "VPCPeeringConnection",
-						APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+						APIVersion: "ec2.aws.wildlife.io/v1alpha1",
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "A-C",
@@ -148,7 +148,7 @@ func TestGetOwnedVPCPeeringConnectionsRef(t *testing.T) {
 			expectedOwnedVPCPeeringConnections: []*corev1.ObjectReference{
 				{
 					Name:       "A-B",
-					APIVersion: "ec2.aws.crossplane.io/v1alpha1",
+					APIVersion: "ec2.aws.wildlife.io/v1alpha1",
 					Kind:       "VPCPeeringConnection",
 				},
 			},


### PR DESCRIPTION
following [the change in the controller](https://github.com/topfreegames/crossplane-provider-aws/pull/1), change the provider to use the custom api version of the vpcpeering resource