### PR TITLE
fix: update range ports in Crossplane Security Group

### DIFF
--- a/controllers/clustermesh/clustermesh_controller.go
+++ b/controllers/clustermesh/clustermesh_controller.go
@@ -414,8 +414,8 @@ func ReconcileSecurityGroups(r *ClusterMeshReconciler, ctx context.Context, clus
 	rules := []sgv1alpha1.IngressRule{
 		{
 			IPProtocol:        "-1", // we support icmp, udp and tcp
-			FromPort:          1,
-			ToPort:            65535,
+			FromPort:          -1,
+			ToPort:            -1,
 			AllowedCIDRBlocks: cidrResults,
 		},
 	}


### PR DESCRIPTION
The PR goal is to fix the Crossplane SecurityGroup not becoming ready even if it's correctly created in the cloud provider. In the end, following the example using -1 for the `portRange` makes it pass the validation