### PR TITLE
chore: when delete security group detach it from the auto-scaling group

### DIFF
--- a/apis/securitygroup/v1alpha1/securitygroup_types.go
+++ b/apis/securitygroup/v1alpha1/securitygroup_types.go
@@ -57,6 +57,8 @@ type IngressRule struct {
 
 // SecurityGroupSpec defines the desired state of SecurityGroup
 type SecurityGroupSpec struct {
+
+	// IngressRules is a list of ingress rules to apply to the Crossplane SecurityGroup.
 	IngressRules []IngressRule `json:"ingressRules,omitempty"`
 	// InfrastructureRef is a reference to a provider-specific resource.
 	InfrastructureRef *corev1.ObjectReference `json:"infrastructureRef,omitempty"`

--- a/config/crd/bases/infrastructure.wildlife.io_securitygroups.yaml
+++ b/config/crd/bases/infrastructure.wildlife.io_securitygroups.yaml
@@ -86,6 +86,8 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               ingressRules:
+                description: IngressRules is a list of ingress rules to apply to the
+                  Crossplane SecurityGroup.
                 items:
                   properties:
                     allowedCIDRs:

--- a/controllers/clustermesh/clustermesh_controller.go
+++ b/controllers/clustermesh/clustermesh_controller.go
@@ -36,11 +36,9 @@ import (
 	crossplanev1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clusterv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/conditions"

--- a/controllers/securitygroup/securitygroup_controller.go
+++ b/controllers/securitygroup/securitygroup_controller.go
@@ -23,7 +23,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/hashicorp/go-multierror"
 	kcontrolplanev1alpha1 "github.com/topfreegames/kubernetes-kops-operator/apis/controlplane/v1alpha1"
 	kinfrastructurev1alpha1 "github.com/topfreegames/kubernetes-kops-operator/apis/infrastructure/v1alpha1"
 	"github.com/topfreegames/kubernetes-kops-operator/pkg/kops"
@@ -36,6 +35,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	crossec2v1beta1 "github.com/crossplane-contrib/provider-aws/apis/ec2/v1beta1"
 	"github.com/go-logr/logr"
+	"github.com/hashicorp/go-multierror"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -133,11 +133,6 @@ func (r *SecurityGroupReconciler) reconcileDelete(ctx context.Context, sg *secur
 		Name: sg.Name,
 	}
 
-	// create a new launch template version without security group
-	// update the autoscaling group with the new version
-	// remove crossplane security group (then aws sg will be removed)
-	// remove finalizers
-
 	csg := &crossec2v1beta1.SecurityGroup{}
 	err := r.Get(ctx, key, csg)
 	if apierrors.IsNotFound(err) {
@@ -145,7 +140,12 @@ func (r *SecurityGroupReconciler) reconcileDelete(ctx context.Context, sg *secur
 		return ctrl.Result{}, nil
 	}
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("could not retrieve security group: %w", err)
+		return ctrl.Result{}, fmt.Errorf("could not retrieve crossplane security group: %w", err)
+	}
+
+	err = r.deleteSGFromASG(ctx, sg, csg)
+	if err != nil {
+		return ctrl.Result{}, err
 	}
 
 	err = r.Delete(ctx, csg)
@@ -414,8 +414,105 @@ func (r *SecurityGroupReconciler) attachSGToASG(ctx context.Context, ec2Client e
 }
 
 // Remove the security group from ASG the removing it from the launch template
-func (r *SecurityGroupReconciler) detachSGFromASG(ctx context.Context, ec2Client ec2.EC2Client, asgClient autoscaling.AutoScalingClient, asgName, sgId string) error {
+func (r *SecurityGroupReconciler) deleteSGFromASG(ctx context.Context, sg *securitygroupv1alpha1.SecurityGroup, csg *crossec2v1beta1.SecurityGroup) error {
 
+	switch sg.Spec.InfrastructureRef.Kind {
+	case "KopsControlPlane":
+		kcp := &kcontrolplanev1alpha1.KopsControlPlane{}
+		key := client.ObjectKey{
+			Namespace: sg.Spec.InfrastructureRef.Namespace,
+			Name:      sg.Spec.InfrastructureRef.Name,
+		}
+		if err := r.Client.Get(ctx, key, kcp); err != nil {
+			return err
+		}
+
+		err := r.deleteSGFromKopsControlPlaneASGs(ctx, sg, csg, kcp)
+		if err != nil {
+			return err
+		}
+	case "KopsMachinePool":
+		kmp := &kinfrastructurev1alpha1.KopsMachinePool{}
+		key := client.ObjectKey{
+			Name:      sg.Spec.InfrastructureRef.Name,
+			Namespace: sg.Spec.InfrastructureRef.Namespace,
+		}
+		if err := r.Client.Get(ctx, key, kmp); err != nil {
+			return err
+		}
+
+		err := r.deleteSGFromKopsMachinePoolASG(ctx, sg, csg, kmp)
+		if err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("infrastructureRef not supported")
+	}
+
+	return nil
+}
+
+func (r *SecurityGroupReconciler) deleteSGFromKopsControlPlaneASGs(ctx context.Context, sg *securitygroupv1alpha1.SecurityGroup, csg *crossec2v1beta1.SecurityGroup, kcp *kcontrolplanev1alpha1.KopsControlPlane) error {
+	_, _, cfg, ec2Client, err := r.getAwsAccountInfo(ctx, kcp)
+	if err != nil {
+		return err
+	}
+
+	asgClient := r.NewAutoScalingClientFactory(cfg)
+
+	kmps, err := kops.GetKopsMachinePoolsWithLabel(ctx, r.Client, "cluster.x-k8s.io/cluster-name", kcp.Name)
+	if err != nil {
+		return err
+	}
+
+	var attachErr error
+	for _, kmp := range kmps {
+		asgName, err := kops.GetAutoScalingGroupNameFromKopsMachinePool(kmp)
+		if err != nil {
+			attachErr = multierror.Append(attachErr, err)
+			continue
+		}
+
+		err = r.detachSGFromASG(ctx, ec2Client, asgClient, *asgName, csg.Status.AtProvider.SecurityGroupID)
+		if err != nil {
+			attachErr = multierror.Append(attachErr, err)
+			continue
+		}
+	}
+
+	if attachErr != nil {
+		return attachErr
+	}
+
+	return nil
+}
+
+func (r *SecurityGroupReconciler) deleteSGFromKopsMachinePoolASG(ctx context.Context, sg *securitygroupv1alpha1.SecurityGroup, csg *crossec2v1beta1.SecurityGroup, kmp *kinfrastructurev1alpha1.KopsMachinePool) error {
+	kcp := &kcontrolplanev1alpha1.KopsControlPlane{}
+	key := client.ObjectKey{
+		Namespace: sg.Spec.InfrastructureRef.Namespace,
+		Name:      kmp.Spec.ClusterName,
+	}
+	if err := r.Client.Get(ctx, key, kcp); err != nil {
+		return err
+	}
+
+	_, _, cfg, ec2Client, err := r.getAwsAccountInfo(ctx, kcp)
+	if err != nil {
+		return err
+	}
+
+	asgClient := r.NewAutoScalingClientFactory(cfg)
+
+	asgName, err := kops.GetAutoScalingGroupNameFromKopsMachinePool(*kmp)
+	if err != nil {
+		return err
+	}
+
+	return r.detachSGFromASG(ctx, ec2Client, asgClient, *asgName, csg.Status.AtProvider.SecurityGroupID)
+}
+
+func (r *SecurityGroupReconciler) detachSGFromASG(ctx context.Context, ec2Client ec2.EC2Client, asgClient autoscaling.AutoScalingClient, asgName, sgId string) error {
 	asg, err := autoscaling.GetAutoScalingGroupByName(ctx, asgClient, asgName)
 	if err != nil {
 		return err

--- a/controllers/securitygroup/securitygroup_controller.go
+++ b/controllers/securitygroup/securitygroup_controller.go
@@ -132,6 +132,11 @@ func (r *SecurityGroupReconciler) reconcileDelete(ctx context.Context, sg *secur
 		Name: sg.Name,
 	}
 
+	// create a new launch template version without security group
+	// update the autoscaling group with the new version
+	// remove crossplane security group (then aws sg will be removed)
+	// remove finalizers
+
 	csg := &crossec2v1beta1.SecurityGroup{}
 	err := r.Get(ctx, key, csg)
 	if apierrors.IsNotFound(err) {
@@ -383,6 +388,35 @@ func (r *SecurityGroupReconciler) attachSGToASG(ctx context.Context, ec2Client e
 	}
 
 	ltVersionOutput, err := ec2.AttachSecurityGroupToLaunchTemplate(ctx, ec2Client, sgId, launchTemplateVersion)
+	if err != nil {
+		return err
+	}
+
+	latestVersion := strconv.FormatInt(*ltVersionOutput.LaunchTemplateVersion.VersionNumber, 10)
+
+	if *asg.LaunchTemplate.Version != latestVersion {
+		_, err = autoscaling.UpdateAutoScalingGroupLaunchTemplate(ctx, asgClient, *ltVersionOutput.LaunchTemplateVersion.LaunchTemplateId, latestVersion, asgName)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Remove the security group from ASG the removing it from the launch template
+func (r *SecurityGroupReconciler) detachSGFromASG(ctx context.Context, ec2Client ec2.EC2Client, asgClient autoscaling.AutoScalingClient, asgName, sgId string) error {
+
+	asg, err := autoscaling.GetAutoScalingGroupByName(ctx, asgClient, asgName)
+	if err != nil {
+		return err
+	}
+
+	launchTemplateVersion, err := ec2.GetLastLaunchTemplateVersion(ctx, ec2Client, *asg.LaunchTemplate.LaunchTemplateId)
+	if err != nil {
+		return err
+	}
+
+	ltVersionOutput, err := ec2.DetachSecurityGroupFromLaunchTemplate(ctx, ec2Client, sgId, launchTemplateVersion)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/crossplane/crossplane-runtime v0.17.0-rc.0.0.20220616115400-a520b60f1661
 	github.com/go-logr/logr v1.2.3
 	github.com/google/go-cmp v0.5.8
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/onsi/ginkgo/v2 v2.1.4
 	github.com/onsi/gomega v1.19.0
 	github.com/pkg/errors v0.9.1
@@ -87,7 +88,6 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-hclog v0.16.2 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
-	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-plugin v1.4.3 // indirect
 	github.com/hashicorp/go-retryablehttp v0.6.6 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect

--- a/pkg/aws/ec2/vpc.go
+++ b/pkg/aws/ec2/vpc.go
@@ -184,12 +184,14 @@ func DetachSecurityGroupFromLaunchTemplate(ctx context.Context, ec2Client EC2Cli
 	}
 
 	networkInterface := launchTemplateVersion.LaunchTemplateData.NetworkInterfaces[0]
-	for i, group := range networkInterface.Groups {
-		if group == securityGroupId {
-			networkInterface.Groups = append(networkInterface.Groups[:i], networkInterface.Groups[i+1:]...)
-			break
+	remainingSecurityGroups := []string{}
+	for _, group := range networkInterface.Groups {
+		if group != securityGroupId {
+			remainingSecurityGroups = append(remainingSecurityGroups, group)
 		}
 	}
+
+	networkInterface.Groups = remainingSecurityGroups
 
 	b, err := json.Marshal(networkInterface)
 	if err != nil {

--- a/pkg/aws/ec2/vpc.go
+++ b/pkg/aws/ec2/vpc.go
@@ -184,10 +184,9 @@ func DetachSecurityGroupFromLaunchTemplate(ctx context.Context, ec2Client EC2Cli
 	}
 
 	networkInterface := launchTemplateVersion.LaunchTemplateData.NetworkInterfaces[0]
-	for _, group := range networkInterface.Groups {
+	for i, group := range networkInterface.Groups {
 		if group == securityGroupId {
-			// remove from groups
-			// networkInterface.Groups = remove(networkInterface.Groups, securityGroupId)
+			networkInterface.Groups = append(networkInterface.Groups[:i], networkInterface.Groups[i+1:]...)
 			break
 		}
 	}

--- a/pkg/aws/ec2/vpc.go
+++ b/pkg/aws/ec2/vpc.go
@@ -176,3 +176,47 @@ func AttachSecurityGroupToLaunchTemplate(ctx context.Context, ec2Client EC2Clien
 
 	return output, nil
 }
+
+func DetachSecurityGroupFromLaunchTemplate(ctx context.Context, ec2Client EC2Client, securityGroupId string, launchTemplateVersion *ec2types.LaunchTemplateVersion) (*ec2.CreateLaunchTemplateVersionOutput, error) {
+
+	if len(launchTemplateVersion.LaunchTemplateData.NetworkInterfaces) == 0 || len(launchTemplateVersion.LaunchTemplateData.NetworkInterfaces[0].Groups) == 0 {
+		return nil, fmt.Errorf("failed to retrieve SGs from LaunchTemplate %s", *launchTemplateVersion.LaunchTemplateId)
+	}
+
+	networkInterface := launchTemplateVersion.LaunchTemplateData.NetworkInterfaces[0]
+	for _, group := range networkInterface.Groups {
+		if group == securityGroupId {
+			// remove from groups
+			// networkInterface.Groups = remove(networkInterface.Groups, securityGroupId)
+			break
+		}
+	}
+
+	b, err := json.Marshal(networkInterface)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to marshal networkInterface")
+	}
+
+	networkInterfaceRequest := ec2types.LaunchTemplateInstanceNetworkInterfaceSpecificationRequest{}
+	err = json.Unmarshal(b, &networkInterfaceRequest)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal networkInterfaceRequest")
+	}
+
+	input := &ec2.CreateLaunchTemplateVersionInput{
+		LaunchTemplateData: &ec2types.RequestLaunchTemplateData{
+			NetworkInterfaces: []ec2types.LaunchTemplateInstanceNetworkInterfaceSpecificationRequest{
+				networkInterfaceRequest,
+			},
+		},
+		LaunchTemplateId: aws.String(*launchTemplateVersion.LaunchTemplateId),
+		SourceVersion:    aws.String("$Latest"),
+	}
+
+	output, err := ec2Client.CreateLaunchTemplateVersion(ctx, input)
+	if err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf("failed to create version in Launch Template %s", *launchTemplateVersion.LaunchTemplateId))
+	}
+
+	return output, nil
+}


### PR DESCRIPTION
This PR goal is to detach the Security Groups from the auto-scaling group when a security group is deleted.