### PR TITLE
feat: add support to pause securitygroup reconciliation

### DIFF
--- a/apis/securitygroup/v1alpha1/securitygroup_types.go
+++ b/apis/securitygroup/v1alpha1/securitygroup_types.go
@@ -39,6 +39,9 @@ const (
 
 	// SecurityGroupAttachmentFailedReason (Severity=Error) indicates that the SecurityGroup couldn´t be attached in the InfrastructureRef.
 	SecurityGroupAttachmentFailedReason = "SecurityGroupAttachmentReconciliationFailed"
+
+	// SecurityGroupAttachmentFailedReason (Severity=Normal) indicates that the reconciliation for the SecurityGroup is paused.
+	ReasonReconcilePaused = "ReconcilePaused"
 )
 
 type IngressRule struct {

--- a/pkg/crossplane/crossplane.go
+++ b/pkg/crossplane/crossplane.go
@@ -3,6 +3,7 @@ package crossplane
 import (
 	"context"
 	"fmt"
+
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	clustermeshv1beta1 "github.com/topfreegames/provider-crossplane/apis/clustermesh/v1alpha1"
@@ -61,7 +62,8 @@ func NewCrossPlaneVPCPeeringConnection(clustermesh *clustermeshv1beta1.ClusterMe
 func NewCrossplaneSecurityGroup(sg *securitygroupv1alpha1.SecurityGroup, vpcId, region *string) *crossec2v1beta1.SecurityGroup {
 	csg := &crossec2v1beta1.SecurityGroup{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: sg.GetName(),
+			Name:        sg.GetName(),
+			Annotations: sg.Annotations,
 		},
 		Spec: crossec2v1beta1.SecurityGroupSpec{
 			ForProvider: crossec2v1beta1.SecurityGroupParameters{
@@ -130,6 +132,7 @@ func CreateOrUpdateCrossplaneSecurityGroup(ctx context.Context, kubeClient clien
 			ingressRules = append(ingressRules, ipPermission)
 		}
 		csg.Spec.ForProvider.Ingress = ingressRules
+		csg.Annotations = sg.Annotations
 		return nil
 	})
 	if err != nil {

--- a/pkg/crossplane/crossplane_test.go
+++ b/pkg/crossplane/crossplane_test.go
@@ -3,6 +3,7 @@ package crossplane
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"testing"
 
 	wildlifecrossec2v1alphav1 "github.com/topfreegames/crossplane-provider-aws/apis/ec2/manualv1alpha1"
@@ -1305,6 +1306,9 @@ func TestCreateOrUpdateCrossplaneSecurityGroup(t *testing.T) {
 			wildlifeSecurityGroup: &securitygroupv1alpha1.SecurityGroup{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-sg",
+					Annotations: map[string]string{
+						securitygroupv1alpha1.ReasonReconcilePaused: "true",
+					},
 				},
 				Spec: securitygroupv1alpha1.SecurityGroupSpec{
 					IngressRules: []securitygroupv1alpha1.IngressRule{
@@ -1332,6 +1336,11 @@ func TestCreateOrUpdateCrossplaneSecurityGroup(t *testing.T) {
 					return false
 				}
 				if csg.Name != "test-sg" {
+					return false
+				}
+				if !reflect.DeepEqual(csg.Annotations, map[string]string{
+					securitygroupv1alpha1.ReasonReconcilePaused: "true",
+				}) {
 					return false
 				}
 				return true


### PR DESCRIPTION
The goal of this PR is to add support to propagate the Crossplane pause annotation to the crossplane security group resource. This was achieved by propagating the annotations from the Wildlife SG resource to the Crossplane SG resource and stopping the reconciliation before the attachment.