### PR TITLE
fix: don't let all rules have the same port numbers

### DIFF
--- a/pkg/crossplane/crossplane.go
+++ b/pkg/crossplane/crossplane.go
@@ -116,6 +116,8 @@ func CreateOrUpdateCrossplaneSecurityGroup(ctx context.Context, kubeClient clien
 	_, err := controllerutil.CreateOrUpdate(ctx, kubeClient, csg, func() error {
 		var ingressRules []crossec2v1beta1.IPPermission
 		for _, ingressRule := range sg.Spec.IngressRules {
+			// https://github.com/golang/go/discussions/56010
+			ingressRule := ingressRule
 			ipPermission := crossec2v1beta1.IPPermission{
 				FromPort:   &ingressRule.FromPort,
 				ToPort:     &ingressRule.ToPort,


### PR DESCRIPTION
Since the reference was being stored then appended into a list, all ingress rules would have the same toPort and fromPort values, taken from the last value in the list.