### PR TITLE
feat: attach security group to current instances of the cloud groups

### DIFF
--- a/.kubernetes/manifests.yaml
+++ b/.kubernetes/manifests.yaml
@@ -569,7 +569,7 @@ data:
     health:
       healthProbeBindAddress: :8081
     metrics:
-      bindAddress: 127.0.0.1:8080
+      bindAddress: :8080
     webhook:
       port: 9443
     leaderElection:
@@ -611,32 +611,25 @@ spec:
   template:
     metadata:
       annotations:
+        ad.datadoghq.com/manager.check_names: '["openmetrics"]'
+        ad.datadoghq.com/manager.init_configs: '[{}]'
+        ad.datadoghq.com/manager.instances: |-
+          [{
+            "metrics": [
+              "controller*",
+              "workqueue*"
+            ],
+            "namespace": "providercrossplane",
+            "prometheus_url": "http://%%host%%:8080/metrics",
+            "send_monotonic_counter": true,
+            "send_distribution_buckets": true
+          }]
         kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: controller-manager
     spec:
       containers:
       - args:
-        - --secure-listen-address=0.0.0.0:8443
-        - --upstream=http://127.0.0.1:8080/
-        - --logtostderr=true
-        - --v=0
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
-        name: kube-rbac-proxy
-        ports:
-        - containerPort: 8443
-          name: https
-          protocol: TCP
-        resources:
-          limits:
-            cpu: 500m
-            memory: 128Mi
-          requests:
-            cpu: 5m
-            memory: 64Mi
-      - args:
-        - --health-probe-bind-address=:8081
-        - --metrics-bind-address=127.0.0.1:8080
         - --leader-elect
         command:
         - /manager
@@ -665,7 +658,7 @@ spec:
               name: aws-credentials
         - name: AWS_REGION
           value: us-east-1
-        image: tfgco/provider-crossplane:v0.0.12-alpha
+        image: tfgco/provider-crossplane:v0.0.13-alpha
         livenessProbe:
           httpGet:
             path: /healthz

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -28,7 +28,10 @@ patchesStrategicMerge:
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
-- manager_auth_proxy_patch.yaml
+# - manager_auth_proxy_patch.yaml
+
+# Enable OpenMetrics collection with Datadog
+- manager_datadog_openmetrics_patch.yaml
 
 # Mount the controller config file for loading manager configurations
 # through a ComponentConfig type

--- a/config/default/manager_datadog_openmetrics_patch.yaml
+++ b/config/default/manager_datadog_openmetrics_patch.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    metadata:
+      annotations:
+        ad.datadoghq.com/manager.check_names: '["openmetrics"]'
+        ad.datadoghq.com/manager.init_configs: '[{}]'
+        ad.datadoghq.com/manager.instances: |-
+          [{
+            "metrics": [
+              "controller*",
+              "workqueue*"
+            ],
+            "namespace": "providercrossplane",
+            "prometheus_url": "http://%%host%%:8080/metrics",
+            "send_monotonic_counter": true,
+            "send_distribution_buckets": true
+          }]

--- a/config/manager/controller_manager_config.yaml
+++ b/config/manager/controller_manager_config.yaml
@@ -3,7 +3,7 @@ kind: ControllerManagerConfig
 health:
   healthProbeBindAddress: :8081
 metrics:
-  bindAddress: 127.0.0.1:8080
+  bindAddress: :8080
 webhook:
   port: 9443
 leaderElection:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,6 +13,6 @@ kind: Kustomization
 images:
 - name: controller
   newName: tfgco/provider-crossplane
-  newTag: v0.0.12-alpha
+  newTag: v0.0.13-alpha
 - name: manager
   newName: tfgco/provider-crossplane

--- a/controllers/clustermesh/clustermesh_controller.go
+++ b/controllers/clustermesh/clustermesh_controller.go
@@ -125,7 +125,7 @@ func (c *ClusterMeshReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return requeue1min, err
 	}
 
-	providerConfigName, cfg, err := util.AwsCredentialsFromKcp(ctx, c.Client, r.kcp)
+	providerConfigName, cfg, err := util.AWSCredentialsFromKCP(ctx, c.Client, r.kcp)
 	if err != nil {
 		return resultError, err
 	}

--- a/controllers/securitygroup/securitygroup_controller.go
+++ b/controllers/securitygroup/securitygroup_controller.go
@@ -23,11 +23,13 @@ import (
 	"strconv"
 	"time"
 
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	kcontrolplanev1alpha1 "github.com/topfreegames/kubernetes-kops-operator/apis/controlplane/v1alpha1"
 	kinfrastructurev1alpha1 "github.com/topfreegames/kubernetes-kops-operator/apis/infrastructure/v1alpha1"
 	"github.com/topfreegames/kubernetes-kops-operator/pkg/kops"
 	securitygroupv1alpha1 "github.com/topfreegames/provider-crossplane/apis/securitygroup/v1alpha1"
 	"github.com/topfreegames/provider-crossplane/pkg/aws/autoscaling"
+
 	"github.com/topfreegames/provider-crossplane/pkg/aws/ec2"
 	"github.com/topfreegames/provider-crossplane/pkg/crossplane"
 	"github.com/topfreegames/provider-crossplane/pkg/util"
@@ -78,22 +80,12 @@ type SecurityGroupReconciler struct {
 
 type SecurityGroupReconciliation struct {
 	SecurityGroupReconciler
-	log                logr.Logger
-	start              time.Time
-	ec2Client          ec2.EC2Client
-	asgClient          autoscaling.AutoScalingClient
-	sg                 *securitygroupv1alpha1.SecurityGroup
-	kmp                *kinfrastructurev1alpha1.KopsMachinePool
-	kcp                *kcontrolplanev1alpha1.KopsControlPlane
-	providerConfigName string
+	log       logr.Logger
+	start     time.Time
+	ec2Client ec2.EC2Client
+	asgClient autoscaling.AutoScalingClient
+	sg        *securitygroupv1alpha1.SecurityGroup
 }
-
-//+kubebuilder:rbac:groups=ec2.aws.wildlife.io,resources=securitygroups,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=ec2.aws.wildlife.io,resources=securitygroups/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=ec2.aws.wildlife.io,resources=securitygroups/finalizers,verbs=update
-//+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=kopsmachinepools,verbs=get;list;watch
-//+kubebuilder:rbac:groups=controlplane.cluster.x-k8s.io,resources=kopscontrolplanes,verbs=get;list;watch
-//+kubebuilder:rbac:groups=ec2.aws.crossplane.io,resources=securitygroups,verbs=get;list;watch;create;update;patch;delete
 
 func DefaultReconciler(mgr manager.Manager) *SecurityGroupReconciler {
 	return &SecurityGroupReconciler{
@@ -106,367 +98,7 @@ func DefaultReconciler(mgr manager.Manager) *SecurityGroupReconciler {
 	}
 }
 
-func (c *SecurityGroupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, rerr error) {
-	r := &SecurityGroupReconciliation{
-		SecurityGroupReconciler: *c,
-		start:                   time.Now(),
-		log:                     ctrl.LoggerFrom(ctx),
-	}
-
-	r.sg = &securitygroupv1alpha1.SecurityGroup{}
-	if err := r.Get(ctx, req.NamespacedName, r.sg); err != nil {
-		return resultError, client.IgnoreNotFound(err)
-	}
-
-	if r.sg.Spec.InfrastructureRef == nil {
-		return resultDefault, fmt.Errorf("infrastructureRef not supported")
-	}
-
-	switch r.sg.Spec.InfrastructureRef.Kind {
-	case "KopsMachinePool":
-		r.kmp = &kinfrastructurev1alpha1.KopsMachinePool{}
-		key := client.ObjectKey{
-			Name:      r.sg.Spec.InfrastructureRef.Name,
-			Namespace: r.sg.Spec.InfrastructureRef.Namespace,
-		}
-		if err := r.Client.Get(ctx, key, r.kmp); err != nil {
-			return resultError, err
-		}
-
-		r.kcp = &kcontrolplanev1alpha1.KopsControlPlane{}
-		key = client.ObjectKey{
-			Name:      r.kmp.Spec.ClusterName,
-			Namespace: r.kmp.ObjectMeta.Namespace,
-		}
-		if err := r.Client.Get(ctx, key, r.kcp); err != nil {
-			return resultError, err
-		}
-	case "KopsControlPlane":
-		r.kcp = &kcontrolplanev1alpha1.KopsControlPlane{}
-		key := client.ObjectKey{
-			Name:      r.sg.Spec.InfrastructureRef.Name,
-			Namespace: r.sg.Spec.InfrastructureRef.Namespace,
-		}
-		if err := r.Client.Get(ctx, key, r.kcp); err != nil {
-			return resultError, err
-		}
-	default:
-		return resultError, fmt.Errorf("infrastructureRef not supported")
-	}
-
-	providerConfigName, cfg, err := util.AwsCredentialsFromKcp(ctx, c.Client, r.kcp)
-	if err != nil {
-		return resultError, err
-	}
-
-	r.providerConfigName = providerConfigName
-
-	r.ec2Client = r.NewEC2ClientFactory(*cfg)
-	r.asgClient = r.NewAutoScalingClientFactory(*cfg)
-
-	r.log.Info(fmt.Sprintf("starting reconcile loop for %s", r.sg.ObjectMeta.GetName()))
-
-	// Initialize the patch helper.
-	patchHelper, err := patch.NewHelper(r.sg, r.Client)
-	if err != nil {
-		r.log.Error(err, "failed to initialize patch helper")
-		return resultError, err
-	}
-
-	defer func() {
-		err = patchHelper.Patch(ctx, r.sg)
-		if err != nil {
-			r.log.Error(rerr, "Failed to patch security group", "sgName", r.sg.Name)
-			if rerr == nil {
-				rerr = err
-			}
-		}
-		r.log.Info(fmt.Sprintf("finished reconcile loop for %s", r.sg.ObjectMeta.GetName()))
-	}()
-
-	return r.Reconcile(ctx)
-}
-
-func (r *SecurityGroupReconciliation) Reconcile(ctx context.Context) (ctrl.Result, error) {
-	if !r.sg.ObjectMeta.DeletionTimestamp.IsZero() {
-		return r.reconcileDelete(ctx, r.sg)
-	}
-
-	if !controllerutil.ContainsFinalizer(r.sg, securityGroupFinalizer) {
-		controllerutil.AddFinalizer(r.sg, securityGroupFinalizer)
-	}
-
-	result, err := r.reconcileNormal(ctx)
-	durationMsg := fmt.Sprintf("finished reconcile security groups loop for %s finished in %s ", r.sg.ObjectMeta.Name, time.Since(r.start).String())
-	if result.RequeueAfter > 0 {
-		durationMsg = fmt.Sprintf("%s, next run in %s", durationMsg, result.RequeueAfter.String())
-	}
-	r.log.Info(durationMsg)
-	return result, err
-}
-
-func (r *SecurityGroupReconciliation) reconcileDelete(ctx context.Context, sg *securitygroupv1alpha1.SecurityGroup) (ctrl.Result, error) {
-	r.log.Info(fmt.Sprintf("reconciling deletion for security group %s\n", sg.Name))
-
-	key := client.ObjectKey{
-		Name: sg.Name,
-	}
-
-	csg := &crossec2v1beta1.SecurityGroup{}
-	err := r.Get(ctx, key, csg)
-	if apierrors.IsNotFound(err) {
-		controllerutil.RemoveFinalizer(sg, securityGroupFinalizer)
-		return ctrl.Result{}, nil
-	}
-	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("could not retrieve crossplane security group: %w", err)
-	}
-
-	err = r.deleteSGFromASG(ctx, sg, csg)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
-	err = r.Delete(ctx, csg)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
-	controllerutil.RemoveFinalizer(sg, securityGroupFinalizer)
-	return ctrl.Result{}, nil
-}
-
-func (r *SecurityGroupReconciliation) reconcileNormal(ctx context.Context) (ctrl.Result, error) {
-
-	if r.kmp != nil {
-		err := r.reconcileKopsMachinePool(ctx)
-		if err != nil {
-			if errors.Is(err, ErrSecurityGroupNotAvailable) {
-				return requeue30seconds, nil
-			}
-			return resultError, err
-		}
-	} else {
-		err := r.reconcileKopsControlPlane(ctx)
-		if err != nil {
-			if errors.Is(err, ErrSecurityGroupNotAvailable) {
-				return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
-			}
-			return resultError, err
-		}
-	}
-
-	r.sg.Status.Ready = true
-	return resultDefault, nil
-}
-
-// TODO: Improve test coverage of this method
-func (r *SecurityGroupReconciliation) reconcileKopsControlPlane(ctx context.Context) error {
-	vpcId, region, err := r.getAwsAccountInfo(ctx, r.kcp)
-	if err != nil {
-		return err
-	}
-
-	csg, err := crossplane.CreateOrUpdateCrossplaneSecurityGroup(ctx, r.Client, vpcId, region, r.providerConfigName, r.sg)
-	if err != nil {
-		conditions.MarkFalse(r.sg,
-			securitygroupv1alpha1.CrossplaneResourceReadyCondition,
-			securitygroupv1alpha1.CrossplaneResourceReconciliationFailedReason,
-			clusterv1beta1.ConditionSeverityError,
-			err.Error(),
-		)
-		return fmt.Errorf("error reconciling crossplane securitygroup: %w", err)
-	}
-
-	if r.sg.GetAnnotations()[AnnotationKeyReconciliationPaused] == "true" {
-		r.log.Info("Reconciliation is paused via the pause annotation", "annotation", AnnotationKeyReconciliationPaused, "value", "true")
-		r.Recorder.Eventf(r.sg, corev1.EventTypeNormal, securitygroupv1alpha1.ReasonReconcilePaused, "Reconciliation is paused via the pause annotation")
-		return nil
-	}
-
-	err = r.Client.Get(ctx, client.ObjectKeyFromObject(csg), csg)
-	if err != nil {
-		conditions.MarkFalse(r.sg,
-			securitygroupv1alpha1.CrossplaneResourceReadyCondition,
-			securitygroupv1alpha1.CrossplaneResourceReconciliationFailedReason,
-			clusterv1beta1.ConditionSeverityError,
-			err.Error(),
-		)
-		return err
-	}
-	conditions.MarkTrue(r.sg, securitygroupv1alpha1.CrossplaneResourceReadyCondition)
-
-	availableCondition := crossplane.GetSecurityGroupReadyCondition(csg)
-	if availableCondition == nil {
-		return ErrSecurityGroupNotAvailable
-	} else {
-		if availableCondition.Status == corev1.ConditionTrue {
-			conditions.MarkTrue(r.sg, securitygroupv1alpha1.SecurityGroupReadyCondition)
-		} else {
-			conditions.MarkFalse(r.sg,
-				securitygroupv1alpha1.SecurityGroupReadyCondition,
-				string(availableCondition.Reason),
-				clusterv1beta1.ConditionSeverityError,
-				availableCondition.Message,
-			)
-			return ErrSecurityGroupNotAvailable
-		}
-	}
-
-	kmps, err := kops.GetKopsMachinePoolsWithLabel(ctx, r.Client, "cluster.x-k8s.io/cluster-name", r.kcp.Name)
-	if err != nil {
-		return err
-	}
-
-	var attachErr error
-	for _, kmp := range kmps {
-		if len(kmp.Spec.SpotInstOptions) != 0 {
-			oceanClient := r.NewOceanCloudProviderAWSFactory()
-			launchSpecs, err := spot.ListVNGsFromClusterName(ctx, oceanClient, kmp.Spec.ClusterName)
-			if err != nil {
-				return fmt.Errorf("error retrieving vngs from clusterName: %w", err)
-			}
-			err = r.attachSGToVNG(ctx, oceanClient, launchSpecs, kmp.Name, csg)
-			if err != nil {
-				r.Recorder.Eventf(r.sg, corev1.EventTypeWarning, securitygroupv1alpha1.SecurityGroupAttachmentFailedReason, err.Error())
-				attachErr = multierror.Append(attachErr, err)
-				continue
-			}
-		} else {
-			asgName, err := kops.GetCloudResourceNameFromKopsMachinePool(kmp)
-			if err != nil {
-				attachErr = multierror.Append(attachErr, err)
-				continue
-			}
-
-			err = r.attachSGToASG(ctx, asgName, csg.Status.AtProvider.SecurityGroupID)
-			if err != nil {
-				r.Recorder.Eventf(r.sg, corev1.EventTypeWarning, securitygroupv1alpha1.SecurityGroupAttachmentFailedReason, err.Error())
-				attachErr = multierror.Append(attachErr, err)
-				continue
-			}
-		}
-	}
-
-	if attachErr != nil {
-		conditions.MarkFalse(r.sg,
-			securitygroupv1alpha1.SecurityGroupAttachedCondition,
-			securitygroupv1alpha1.SecurityGroupAttachmentFailedReason,
-			clusterv1beta1.ConditionSeverityError,
-			attachErr.Error(),
-		)
-	} else {
-		conditions.MarkTrue(r.sg, securitygroupv1alpha1.SecurityGroupAttachedCondition)
-		conditions.MarkTrue(r.sg, securitygroupv1alpha1.SecurityGroupReadyCondition)
-	}
-
-	return attachErr
-}
-
-func (r *SecurityGroupReconciliation) reconcileKopsMachinePool(ctx context.Context) error {
-	kcp := &kcontrolplanev1alpha1.KopsControlPlane{}
-	key := client.ObjectKey{
-		Namespace: r.sg.Spec.InfrastructureRef.Namespace,
-		Name:      r.kmp.Spec.ClusterName,
-	}
-	if err := r.Client.Get(ctx, key, kcp); err != nil {
-		return err
-	}
-
-	vpcId, region, err := r.getAwsAccountInfo(ctx, kcp)
-	if err != nil {
-		return fmt.Errorf("error retrieving aws account: %w", err)
-	}
-
-	csg, err := crossplane.CreateOrUpdateCrossplaneSecurityGroup(ctx, r.Client, vpcId, region, r.providerConfigName, r.sg)
-	if err != nil {
-		conditions.MarkFalse(r.sg,
-			securitygroupv1alpha1.CrossplaneResourceReadyCondition,
-			securitygroupv1alpha1.CrossplaneResourceReconciliationFailedReason,
-			clusterv1beta1.ConditionSeverityError,
-			err.Error(),
-		)
-		return fmt.Errorf("error creating crossplane securitygroup: %w", err)
-	}
-
-	if r.sg.GetAnnotations()[AnnotationKeyReconciliationPaused] == "true" {
-		r.log.Info("Reconciliation is paused via the pause annotation", "annotation", AnnotationKeyReconciliationPaused, "value", "true")
-		r.Recorder.Eventf(r.sg, corev1.EventTypeNormal, securitygroupv1alpha1.ReasonReconcilePaused, "Reconciliation is paused via the pause annotation")
-		return nil
-	}
-
-	err = r.Client.Get(ctx, client.ObjectKeyFromObject(csg), csg)
-	if err != nil {
-		conditions.MarkFalse(r.sg,
-			securitygroupv1alpha1.CrossplaneResourceReadyCondition,
-			securitygroupv1alpha1.CrossplaneResourceReconciliationFailedReason,
-			clusterv1beta1.ConditionSeverityError,
-			err.Error(),
-		)
-		return err
-	}
-	conditions.MarkTrue(r.sg, securitygroupv1alpha1.CrossplaneResourceReadyCondition)
-
-	availableCondition := crossplane.GetSecurityGroupReadyCondition(csg)
-	if availableCondition == nil {
-		return ErrSecurityGroupNotAvailable
-	} else {
-		if availableCondition.Status == corev1.ConditionTrue {
-			conditions.MarkTrue(r.sg, securitygroupv1alpha1.SecurityGroupReadyCondition)
-		} else {
-			conditions.MarkFalse(r.sg,
-				securitygroupv1alpha1.SecurityGroupReadyCondition,
-				string(availableCondition.Reason),
-				clusterv1beta1.ConditionSeverityError,
-				availableCondition.Message,
-			)
-			return ErrSecurityGroupNotAvailable
-		}
-	}
-
-	if len(r.kmp.Spec.SpotInstOptions) != 0 {
-		oceanClient := r.NewOceanCloudProviderAWSFactory()
-		launchSpecs, err := spot.ListVNGsFromClusterName(ctx, oceanClient, r.kmp.Spec.ClusterName)
-		if err != nil {
-			return fmt.Errorf("error retrieving vngs from clusterName: %w", err)
-		}
-		err = r.attachSGToVNG(ctx, oceanClient, launchSpecs, r.kmp.Name, csg)
-		if err != nil {
-			conditions.MarkFalse(r.sg,
-				securitygroupv1alpha1.SecurityGroupAttachedCondition,
-				securitygroupv1alpha1.SecurityGroupAttachmentFailedReason,
-				clusterv1beta1.ConditionSeverityError,
-				err.Error(),
-			)
-			return err
-		}
-
-	} else {
-		asgName, err := kops.GetCloudResourceNameFromKopsMachinePool(*r.kmp)
-		if err != nil {
-			return fmt.Errorf("error retrieving ASG name: %w", err)
-		}
-
-		err = r.attachSGToASG(ctx, asgName, csg.Status.AtProvider.SecurityGroupID)
-		if err != nil {
-			conditions.MarkFalse(r.sg,
-				securitygroupv1alpha1.SecurityGroupAttachedCondition,
-				securitygroupv1alpha1.SecurityGroupAttachmentFailedReason,
-				clusterv1beta1.ConditionSeverityError,
-				err.Error(),
-			)
-			return err
-		}
-
-	}
-
-	conditions.MarkTrue(r.sg, securitygroupv1alpha1.SecurityGroupAttachedCondition)
-	conditions.MarkTrue(r.sg, securitygroupv1alpha1.SecurityGroupReadyCondition)
-
-	return nil
-}
-
-func (r *SecurityGroupReconciliation) getAwsAccountInfo(ctx context.Context, kcp *kcontrolplanev1alpha1.KopsControlPlane) (*string, *string, error) {
+func (r *SecurityGroupReconciliation) getAWSAccountInfo(ctx context.Context, kcp *kcontrolplanev1alpha1.KopsControlPlane) (*string, *string, error) {
 	subnet, err := kops.GetSubnetFromKopsControlPlane(kcp)
 	if err != nil {
 		return aws.String(""), aws.String(""), err
@@ -497,31 +129,411 @@ func (r *SecurityGroupReconciliation) getAwsAccountInfo(ctx context.Context, kcp
 	return vpcId, region, nil
 }
 
+//+kubebuilder:rbac:groups=ec2.aws.wildlife.io,resources=securitygroups,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=ec2.aws.wildlife.io,resources=securitygroups/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=ec2.aws.wildlife.io,resources=securitygroups/finalizers,verbs=update
+//+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=kopsmachinepools,verbs=get;list;watch
+//+kubebuilder:rbac:groups=controlplane.cluster.x-k8s.io,resources=kopscontrolplanes,verbs=get;list;watch
+//+kubebuilder:rbac:groups=ec2.aws.crossplane.io,resources=securitygroups,verbs=get;list;watch;create;update;patch;delete
+
+func (c *SecurityGroupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, rerr error) {
+	r := &SecurityGroupReconciliation{
+		SecurityGroupReconciler: *c,
+		start:                   time.Now(),
+		log:                     ctrl.LoggerFrom(ctx),
+	}
+
+	r.sg = &securitygroupv1alpha1.SecurityGroup{}
+	if err := r.Get(ctx, req.NamespacedName, r.sg); err != nil {
+		return resultError, client.IgnoreNotFound(err)
+	}
+
+	if r.sg.Spec.InfrastructureRef == nil {
+		return resultDefault, fmt.Errorf("infrastructureRef not supported")
+	}
+
+	if r.sg.GetAnnotations()[AnnotationKeyReconciliationPaused] == "true" {
+		r.log.Info("Reconciliation is paused via the pause annotation", "annotation", AnnotationKeyReconciliationPaused, "value", "true")
+		r.Recorder.Eventf(r.sg, corev1.EventTypeNormal, securitygroupv1alpha1.ReasonReconcilePaused, "Reconciliation is paused via the pause annotation")
+		return resultDefault, nil
+	}
+
+	r.log.Info(fmt.Sprintf("starting reconcile loop for %s", r.sg.ObjectMeta.GetName()))
+
+	// Initialize the patch helper.
+	patchHelper, err := patch.NewHelper(r.sg, r.Client)
+	if err != nil {
+		r.log.Error(err, "failed to initialize patch helper")
+		return resultError, err
+	}
+
+	defer func() {
+		err = patchHelper.Patch(ctx, r.sg)
+		if err != nil {
+			r.log.Error(rerr, "Failed to patch security group", "sgName", r.sg.Name)
+			if rerr == nil {
+				rerr = err
+			}
+		}
+		r.log.Info(fmt.Sprintf("finished reconcile loop for %s", r.sg.ObjectMeta.GetName()))
+	}()
+
+	if !r.sg.ObjectMeta.DeletionTimestamp.IsZero() {
+		return r.reconcileDelete(ctx, r.sg)
+	}
+
+	return r.reconcileNormal(ctx)
+}
+
+func (r *SecurityGroupReconciliation) reconcileNormal(ctx context.Context) (ctrl.Result, error) {
+	if !controllerutil.ContainsFinalizer(r.sg, securityGroupFinalizer) {
+		controllerutil.AddFinalizer(r.sg, securityGroupFinalizer)
+	}
+
+	switch r.sg.Spec.InfrastructureRef.Kind {
+	case "KopsMachinePool":
+		kmp := kinfrastructurev1alpha1.KopsMachinePool{}
+		key := client.ObjectKey{
+			Name:      r.sg.Spec.InfrastructureRef.Name,
+			Namespace: r.sg.Spec.InfrastructureRef.Namespace,
+		}
+		if err := r.Client.Get(ctx, key, &kmp); err != nil {
+			return resultError, err
+		}
+
+		kcp := &kcontrolplanev1alpha1.KopsControlPlane{}
+		key = client.ObjectKey{
+			Name:      kmp.Spec.ClusterName,
+			Namespace: kmp.ObjectMeta.Namespace,
+		}
+		if err := r.Client.Get(ctx, key, kcp); err != nil {
+			return resultError, err
+		}
+		err := r.reconcileKopsMachinePool(ctx, kcp, kmp)
+		if err != nil {
+			if errors.Is(err, ErrSecurityGroupNotAvailable) {
+				return requeue30seconds, nil
+			}
+			return resultError, err
+		}
+	case "KopsControlPlane":
+		kcp := &kcontrolplanev1alpha1.KopsControlPlane{}
+		key := client.ObjectKey{
+			Name:      r.sg.Spec.InfrastructureRef.Name,
+			Namespace: r.sg.Spec.InfrastructureRef.Namespace,
+		}
+		if err := r.Client.Get(ctx, key, kcp); err != nil {
+			return resultError, err
+		}
+
+		kmps, err := kops.GetKopsMachinePoolsWithLabel(ctx, r.Client, "cluster.x-k8s.io/cluster-name", kcp.Name)
+		if err != nil {
+			return resultError, err
+		}
+		err = r.reconcileKopsMachinePool(ctx, kcp, kmps...)
+		if err != nil {
+			if errors.Is(err, ErrSecurityGroupNotAvailable) {
+				return requeue30seconds, nil
+			}
+			return resultError, err
+		}
+	default:
+		return resultError, fmt.Errorf("infrastructureRef not supported")
+	}
+
+	r.sg.Status.Ready = true
+	return resultDefault, nil
+}
+
+func (r *SecurityGroupReconciliation) reconcileKopsMachinePool(ctx context.Context, kcp *kcontrolplanev1alpha1.KopsControlPlane, kmps ...kinfrastructurev1alpha1.KopsMachinePool) error {
+	providerConfigName, cfg, err := util.AWSCredentialsFromKCP(ctx, r.Client, kcp)
+	if err != nil {
+		return err
+	}
+
+	r.ec2Client = r.NewEC2ClientFactory(*cfg)
+	r.asgClient = r.NewAutoScalingClientFactory(*cfg)
+
+	vpcId, region, err := r.getAWSAccountInfo(ctx, kcp)
+	if err != nil {
+		return fmt.Errorf("error retrieving aws account: %w", err)
+	}
+
+	csg, err := crossplane.CreateOrUpdateCrossplaneSecurityGroup(ctx, r.Client, vpcId, region, providerConfigName, r.sg)
+	if err != nil {
+		conditions.MarkFalse(r.sg,
+			securitygroupv1alpha1.CrossplaneResourceReadyCondition,
+			securitygroupv1alpha1.CrossplaneResourceReconciliationFailedReason,
+			clusterv1beta1.ConditionSeverityError,
+			err.Error(),
+		)
+		return fmt.Errorf("error creating crossplane securitygroup: %w", err)
+	}
+
+	err = r.Client.Get(ctx, client.ObjectKeyFromObject(csg), csg)
+	if err != nil {
+		conditions.MarkFalse(r.sg,
+			securitygroupv1alpha1.CrossplaneResourceReadyCondition,
+			securitygroupv1alpha1.CrossplaneResourceReconciliationFailedReason,
+			clusterv1beta1.ConditionSeverityError,
+			err.Error(),
+		)
+		return err
+	}
+	conditions.MarkTrue(r.sg, securitygroupv1alpha1.CrossplaneResourceReadyCondition)
+
+	availableCondition := crossplane.GetSecurityGroupReadyCondition(csg)
+	if availableCondition == nil {
+		return ErrSecurityGroupNotAvailable
+	} else {
+		if availableCondition.Status == corev1.ConditionTrue {
+			conditions.MarkTrue(r.sg, securitygroupv1alpha1.SecurityGroupReadyCondition)
+		} else {
+			conditions.MarkFalse(r.sg,
+				securitygroupv1alpha1.SecurityGroupReadyCondition,
+				string(availableCondition.Reason),
+				clusterv1beta1.ConditionSeverityError,
+				availableCondition.Message,
+			)
+			return ErrSecurityGroupNotAvailable
+		}
+	}
+
+	var attachErr error
+	for _, kmp := range kmps {
+		if len(kmp.Spec.SpotInstOptions) != 0 {
+			oceanClient := r.NewOceanCloudProviderAWSFactory()
+			launchSpecs, err := spot.ListVNGsFromClusterName(ctx, oceanClient, kmp.Spec.ClusterName)
+			if err != nil {
+				return err
+			}
+			err = r.attachSGToVNG(ctx, oceanClient, launchSpecs, kmp.Name, csg)
+			if err != nil {
+				r.Recorder.Eventf(r.sg, corev1.EventTypeWarning, securitygroupv1alpha1.SecurityGroupAttachmentFailedReason, err.Error())
+				attachErr = multierror.Append(attachErr, err)
+				continue
+			}
+		} else {
+			asgName, err := kops.GetCloudResourceNameFromKopsMachinePool(kmp)
+			if err != nil {
+				attachErr = multierror.Append(attachErr, err)
+				continue
+			}
+
+			err = r.attachSGToASG(ctx, asgName, csg.Status.AtProvider.SecurityGroupID)
+			if err != nil {
+				r.Recorder.Eventf(r.sg, corev1.EventTypeWarning, securitygroupv1alpha1.SecurityGroupAttachmentFailedReason, err.Error())
+				attachErr = multierror.Append(attachErr, err)
+				continue
+			}
+		}
+	}
+	if attachErr != nil {
+		conditions.MarkFalse(r.sg,
+			securitygroupv1alpha1.SecurityGroupAttachedCondition,
+			securitygroupv1alpha1.SecurityGroupAttachmentFailedReason,
+			clusterv1beta1.ConditionSeverityError,
+			attachErr.Error(),
+		)
+	} else {
+		conditions.MarkTrue(r.sg, securitygroupv1alpha1.SecurityGroupAttachedCondition)
+		conditions.MarkTrue(r.sg, securitygroupv1alpha1.SecurityGroupReadyCondition)
+	}
+
+	return attachErr
+}
+
 func (r *SecurityGroupReconciliation) attachSGToVNG(ctx context.Context, oceanClient spot.OceanClient, launchSpecs []*oceanaws.LaunchSpec, kmpName string, csg *crossec2v1beta1.SecurityGroup) error {
 	for _, vng := range launchSpecs {
 		for _, labels := range vng.Labels {
 			if *labels.Key == "kops.k8s.io/instance-group-name" && *labels.Value == kmpName {
-				securityGroupsIDs := vng.SecurityGroupIDs
-				if slices.Contains(securityGroupsIDs, csg.Status.AtProvider.SecurityGroupID) {
-					return nil
+				if !slices.Contains(vng.SecurityGroupIDs, csg.Status.AtProvider.SecurityGroupID) {
+					vng.SecurityGroupIDs = append(vng.SecurityGroupIDs, csg.Status.AtProvider.SecurityGroupID)
+					vng.SetSecurityGroupIDs(vng.SecurityGroupIDs)
+					// We need to clean these values because of the spot update API
+					vng.CreatedAt = nil
+					vng.OceanID = nil
+					vng.UpdatedAt = nil
+					_, err := oceanClient.UpdateLaunchSpec(ctx, &oceanaws.UpdateLaunchSpecInput{
+						LaunchSpec: vng,
+					})
+					if err != nil {
+						return fmt.Errorf("error updating ocean cluster launch spec: %w", err)
+					}
 				}
-				securityGroupsIDs = append(securityGroupsIDs, csg.Status.AtProvider.SecurityGroupID)
-				vng.SetSecurityGroupIDs(securityGroupsIDs)
-				// We need to clean these values because of the spot update API
-				vng.CreatedAt = nil
-				vng.OceanID = nil
-				vng.UpdatedAt = nil
-				_, err := oceanClient.UpdateLaunchSpec(ctx, &oceanaws.UpdateLaunchSpecInput{
-					LaunchSpec: vng,
+
+				reservations, err := ec2.GetReservationsUsingFilters(ctx, r.ec2Client, []ec2types.Filter{
+					{
+						Name:   aws.String("tag:spotinst:ocean:launchspec:name"),
+						Values: []string{*vng.Name},
+					},
+					{
+						Name:   aws.String("tag:spotinst:aws:ec2:group:createdBy"),
+						Values: []string{"spotinst"},
+					},
+					{
+						Name:   aws.String("instance-state-name"),
+						Values: []string{"running"},
+					},
 				})
 				if err != nil {
-					return fmt.Errorf("error updating ocean cluster launch spec: %w", err)
+					return err
 				}
+
+				instanceIDs := []string{}
+				for _, reservation := range reservations {
+					for _, instance := range reservation.Instances {
+						instanceIDs = append(instanceIDs, *instance.InstanceId)
+					}
+				}
+
+				err = ec2.AttachSecurityGroupToInstances(ctx, r.ec2Client, instanceIDs, csg.Status.AtProvider.SecurityGroupID)
+				if err != nil {
+					r.Recorder.Eventf(r.sg, corev1.EventTypeWarning, "SecurityGroupInstancesAttachmentFailed", err.Error())
+				}
+
 				return nil
 			}
 		}
 	}
 	return fmt.Errorf("error no vng found with instance group name: %s", kmpName)
+}
+
+func (r *SecurityGroupReconciliation) attachSGToASG(ctx context.Context, asgName, sgID string) error {
+
+	asg, err := autoscaling.GetAutoScalingGroupByName(ctx, r.asgClient, asgName)
+	if err != nil {
+		return err
+	}
+
+	launchTemplateVersion, err := ec2.GetLastLaunchTemplateVersion(ctx, r.ec2Client, *asg.LaunchTemplate.LaunchTemplateId)
+	if err != nil {
+		return err
+	}
+
+	ltVersionOutput, err := ec2.AttachSecurityGroupToLaunchTemplate(ctx, r.ec2Client, sgID, launchTemplateVersion)
+	if err != nil {
+		return err
+	}
+
+	latestVersion := strconv.FormatInt(*ltVersionOutput.LaunchTemplateVersion.VersionNumber, 10)
+
+	if *asg.LaunchTemplate.Version != latestVersion {
+		_, err = autoscaling.UpdateAutoScalingGroupLaunchTemplate(ctx, r.asgClient, *ltVersionOutput.LaunchTemplateVersion.LaunchTemplateId, latestVersion, asgName)
+		if err != nil {
+			return err
+		}
+	}
+
+	instanceIDs := []string{}
+	for _, instance := range asg.Instances {
+		instanceIDs = append(instanceIDs, *instance.InstanceId)
+	}
+
+	err = ec2.AttachSecurityGroupToInstances(ctx, r.ec2Client, instanceIDs, sgID)
+	if err != nil {
+		r.Recorder.Eventf(r.sg, corev1.EventTypeWarning, "SecurityGroupInstancesAttachmentFailed", err.Error())
+	}
+
+	return nil
+}
+
+func (r *SecurityGroupReconciliation) reconcileDelete(ctx context.Context, sg *securitygroupv1alpha1.SecurityGroup) (ctrl.Result, error) {
+	r.log.Info(fmt.Sprintf("reconciling deletion for security group %s\n", sg.Name))
+
+	key := client.ObjectKey{
+		Name: sg.Name,
+	}
+
+	csg := &crossec2v1beta1.SecurityGroup{}
+	err := r.Get(ctx, key, csg)
+	if apierrors.IsNotFound(err) {
+		controllerutil.RemoveFinalizer(sg, securityGroupFinalizer)
+		return ctrl.Result{}, nil
+	}
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("could not retrieve crossplane security group: %w", err)
+	}
+
+	switch r.sg.Spec.InfrastructureRef.Kind {
+	case "KopsMachinePool":
+		kmp := kinfrastructurev1alpha1.KopsMachinePool{}
+		key := client.ObjectKey{
+			Name:      sg.Spec.InfrastructureRef.Name,
+			Namespace: sg.Spec.InfrastructureRef.Namespace,
+		}
+		if err := r.Client.Get(ctx, key, &kmp); err != nil {
+			return resultError, err
+		}
+
+		err := r.detachSGFromKopsMachinePool(ctx, csg, kmp)
+		if err != nil {
+			return resultError, err
+		}
+	case "KopsControlPlane":
+		kcp := &kcontrolplanev1alpha1.KopsControlPlane{}
+		key := client.ObjectKey{
+			Namespace: sg.Spec.InfrastructureRef.Namespace,
+			Name:      sg.Spec.InfrastructureRef.Name,
+		}
+		if err := r.Client.Get(ctx, key, kcp); err != nil {
+			return resultError, err
+		}
+
+		kmps, err := kops.GetKopsMachinePoolsWithLabel(ctx, r.Client, "cluster.x-k8s.io/cluster-name", kcp.Name)
+		if err != nil {
+			return resultError, err
+		}
+
+		err = r.detachSGFromKopsMachinePool(ctx, csg, kmps...)
+		if err != nil {
+			return resultError, err
+		}
+	default:
+		return resultError, fmt.Errorf("infrastructureRef not supported")
+	}
+
+	err = r.Delete(ctx, csg)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	controllerutil.RemoveFinalizer(sg, securityGroupFinalizer)
+	return ctrl.Result{}, nil
+}
+
+func (r *SecurityGroupReconciliation) detachSGFromKopsMachinePool(ctx context.Context, csg *crossec2v1beta1.SecurityGroup, kmps ...kinfrastructurev1alpha1.KopsMachinePool) error {
+
+	var detachErr error
+	for _, kmp := range kmps {
+		if len(kmp.Spec.SpotInstOptions) != 0 {
+			oceanClient := r.NewOceanCloudProviderAWSFactory()
+			launchSpecs, err := spot.ListVNGsFromClusterName(ctx, oceanClient, kmp.Spec.ClusterName)
+			if err != nil {
+				return err
+			}
+			err = r.detachSGFromVNG(ctx, oceanClient, launchSpecs, kmp.Name, csg)
+			if err != nil {
+				detachErr = multierror.Append(detachErr, err)
+				continue
+			}
+		} else {
+			asgName, err := kops.GetCloudResourceNameFromKopsMachinePool(kmp)
+			if err != nil {
+				detachErr = multierror.Append(detachErr, err)
+				continue
+			}
+
+			err = r.detachSGFromASG(ctx, asgName, csg.Status.AtProvider.SecurityGroupID)
+			if err != nil {
+				detachErr = multierror.Append(detachErr, err)
+				continue
+			}
+			// TODO: Do we want to detach the SGs from the instances as well?
+		}
+	}
+
+	return detachErr
 }
 
 func (r *SecurityGroupReconciliation) detachSGFromVNG(ctx context.Context, oceanClient spot.OceanClient, launchSpecs []*oceanaws.LaunchSpec, kmpName string, csg *crossec2v1beta1.SecurityGroup) error {
@@ -550,143 +562,6 @@ func (r *SecurityGroupReconciliation) detachSGFromVNG(ctx context.Context, ocean
 		}
 	}
 	return fmt.Errorf("error no vng found with instance group name: %s", kmpName)
-}
-
-func (r *SecurityGroupReconciliation) attachSGToASG(ctx context.Context, asgName, sgId string) error {
-
-	asg, err := autoscaling.GetAutoScalingGroupByName(ctx, r.asgClient, asgName)
-	if err != nil {
-		return err
-	}
-
-	launchTemplateVersion, err := ec2.GetLastLaunchTemplateVersion(ctx, r.ec2Client, *asg.LaunchTemplate.LaunchTemplateId)
-	if err != nil {
-		return err
-	}
-
-	ltVersionOutput, err := ec2.AttachSecurityGroupToLaunchTemplate(ctx, r.ec2Client, sgId, launchTemplateVersion)
-	if err != nil {
-		return err
-	}
-
-	latestVersion := strconv.FormatInt(*ltVersionOutput.LaunchTemplateVersion.VersionNumber, 10)
-
-	if *asg.LaunchTemplate.Version != latestVersion {
-		_, err = autoscaling.UpdateAutoScalingGroupLaunchTemplate(ctx, r.asgClient, *ltVersionOutput.LaunchTemplateVersion.LaunchTemplateId, latestVersion, asgName)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// Remove the security group from ASG the removing it from the launch template
-func (r *SecurityGroupReconciliation) deleteSGFromASG(ctx context.Context, sg *securitygroupv1alpha1.SecurityGroup, csg *crossec2v1beta1.SecurityGroup) error {
-
-	switch sg.Spec.InfrastructureRef.Kind {
-	case "KopsControlPlane":
-		kcp := &kcontrolplanev1alpha1.KopsControlPlane{}
-		key := client.ObjectKey{
-			Namespace: sg.Spec.InfrastructureRef.Namespace,
-			Name:      sg.Spec.InfrastructureRef.Name,
-		}
-		if err := r.Client.Get(ctx, key, kcp); err != nil {
-			return err
-		}
-
-		err := r.deleteSGFromKopsControlPlaneASGs(ctx, sg, csg, kcp)
-		if err != nil {
-			return err
-		}
-	case "KopsMachinePool":
-		kmp := &kinfrastructurev1alpha1.KopsMachinePool{}
-		key := client.ObjectKey{
-			Name:      sg.Spec.InfrastructureRef.Name,
-			Namespace: sg.Spec.InfrastructureRef.Namespace,
-		}
-		if err := r.Client.Get(ctx, key, kmp); err != nil {
-			return err
-		}
-
-		err := r.deleteSGFromKopsMachinePoolASG(ctx, sg, csg, kmp)
-		if err != nil {
-			return err
-		}
-	default:
-		return fmt.Errorf("infrastructureRef not supported")
-	}
-
-	return nil
-}
-
-func (r *SecurityGroupReconciliation) deleteSGFromKopsControlPlaneASGs(ctx context.Context, sg *securitygroupv1alpha1.SecurityGroup, csg *crossec2v1beta1.SecurityGroup, kcp *kcontrolplanev1alpha1.KopsControlPlane) error {
-	kmps, err := kops.GetKopsMachinePoolsWithLabel(ctx, r.Client, "cluster.x-k8s.io/cluster-name", kcp.Name)
-	if err != nil {
-		return err
-	}
-
-	var attachErr error
-	for _, kmp := range kmps {
-		if len(kmp.Spec.SpotInstOptions) != 0 {
-			oceanClient := r.NewOceanCloudProviderAWSFactory()
-			launchSpecs, err := spot.ListVNGsFromClusterName(ctx, oceanClient, kmp.Spec.ClusterName)
-			if err != nil {
-				return fmt.Errorf("error retrieving vngs from clusterName: %w", err)
-			}
-			err = r.detachSGFromVNG(ctx, oceanClient, launchSpecs, kmp.Name, csg)
-			if err != nil {
-				attachErr = multierror.Append(attachErr, err)
-				continue
-			}
-		} else {
-			asgName, err := kops.GetCloudResourceNameFromKopsMachinePool(kmp)
-			if err != nil {
-				attachErr = multierror.Append(attachErr, err)
-				continue
-			}
-
-			err = r.detachSGFromASG(ctx, asgName, csg.Status.AtProvider.SecurityGroupID)
-			if err != nil {
-				attachErr = multierror.Append(attachErr, err)
-				continue
-			}
-		}
-	}
-
-	if attachErr != nil {
-		return attachErr
-	}
-
-	return nil
-}
-
-func (r *SecurityGroupReconciliation) deleteSGFromKopsMachinePoolASG(ctx context.Context, sg *securitygroupv1alpha1.SecurityGroup, csg *crossec2v1beta1.SecurityGroup, kmp *kinfrastructurev1alpha1.KopsMachinePool) error {
-	kcp := &kcontrolplanev1alpha1.KopsControlPlane{}
-	key := client.ObjectKey{
-		Namespace: sg.Spec.InfrastructureRef.Namespace,
-		Name:      kmp.Spec.ClusterName,
-	}
-	if err := r.Client.Get(ctx, key, kcp); err != nil {
-		return err
-	}
-
-	if len(kmp.Spec.SpotInstOptions) != 0 {
-		oceanClient := r.NewOceanCloudProviderAWSFactory()
-		launchSpecs, err := spot.ListVNGsFromClusterName(ctx, oceanClient, kmp.Spec.ClusterName)
-		if err != nil {
-			return fmt.Errorf("error retrieving vngs from clusterName: %w", err)
-		}
-
-		return r.detachSGFromVNG(ctx, oceanClient, launchSpecs, kmp.Name, csg)
-
-	} else {
-		asgName, err := kops.GetCloudResourceNameFromKopsMachinePool(*kmp)
-		if err != nil {
-			return err
-		}
-
-		return r.detachSGFromASG(ctx, asgName, csg.Status.AtProvider.SecurityGroupID)
-	}
 }
 
 func (r *SecurityGroupReconciliation) detachSGFromASG(ctx context.Context, asgName, sgId string) error {

--- a/controllers/securitygroup/securitygroup_controller_test.go
+++ b/controllers/securitygroup/securitygroup_controller_test.go
@@ -14,6 +14,7 @@ import (
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	crossec2v1beta1 "github.com/crossplane-contrib/provider-aws/apis/ec2/v1beta1"
 	crossplanev1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	"github.com/hashicorp/go-multierror"
 	oceanaws "github.com/spotinst/spotinst-sdk-go/service/ocean/providers/aws"
 	kcontrolplanev1alpha1 "github.com/topfreegames/kubernetes-kops-operator/apis/controlplane/v1alpha1"
 	kinfrastructurev1alpha1 "github.com/topfreegames/kubernetes-kops-operator/apis/infrastructure/v1alpha1"
@@ -28,6 +29,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
 	kopsapi "k8s.io/kops/pkg/apis/kops"
@@ -215,7 +217,7 @@ func TestSecurityGroupReconciler(t *testing.T) {
 	testCases := []struct {
 		description               string
 		k8sObjects                []client.Object
-		isErrorExpected           bool
+		errorExpected             error
 		expectedDeletion          bool
 		expectedProviderConfigRef *string
 	}{
@@ -241,7 +243,7 @@ func TestSecurityGroupReconciler(t *testing.T) {
 					},
 				},
 			},
-			isErrorExpected: true,
+			errorExpected: errors.New("infrastructureRef not supported"),
 		},
 		{
 			description: "should create a SecurityGroup with KopsControlPlane infrastructureRef",
@@ -271,7 +273,6 @@ func TestSecurityGroupReconciler(t *testing.T) {
 					},
 				},
 			},
-			isErrorExpected: false,
 		},
 		{
 			description: "should fail with InfrastructureRef Kind different from KopsMachinePool and KopsControlPlane",
@@ -301,7 +302,7 @@ func TestSecurityGroupReconciler(t *testing.T) {
 					},
 				},
 			},
-			isErrorExpected: true,
+			errorExpected: errors.New("infrastructureRef not supported"),
 		},
 		{
 			description: "should remove SecurityGroup with DeletionTimestamp",
@@ -334,7 +335,6 @@ func TestSecurityGroupReconciler(t *testing.T) {
 					},
 				},
 			},
-			isErrorExpected:  false,
 			expectedDeletion: true,
 		},
 		{
@@ -365,8 +365,21 @@ func TestSecurityGroupReconciler(t *testing.T) {
 					},
 				},
 			},
-			isErrorExpected:           false,
 			expectedProviderConfigRef: &kcpWithIdentityRef.Spec.IdentityRef.Name,
+		},
+		{
+			description: "should fail when not finding KopsMachinePool",
+			k8sObjects: []client.Object{
+				cluster, kcp, sg, defaultSecret,
+			},
+			errorExpected: apierrors.NewNotFound(schema.GroupResource{Group: "infrastructure.cluster.x-k8s.io", Resource: "kopsmachinepools"}, kmp.Name),
+		},
+		{
+			description: "should fail when not finding KopsControlPlane",
+			k8sObjects: []client.Object{
+				kmp, cluster, sg, defaultSecret,
+			},
+			errorExpected: apierrors.NewNotFound(schema.GroupResource{Group: "controlplane.cluster.x-k8s.io", Resource: "kopscontrolplanes"}, kcp.Name),
 		},
 	}
 	RegisterFailHandler(Fail)
@@ -419,7 +432,7 @@ func TestSecurityGroupReconciler(t *testing.T) {
 				},
 			})
 
-			if !tc.isErrorExpected {
+			if tc.errorExpected == nil {
 				crosssg := &crossec2v1beta1.SecurityGroup{}
 				key := client.ObjectKey{
 					Name: sg.ObjectMeta.Name,
@@ -436,180 +449,8 @@ func TestSecurityGroupReconciler(t *testing.T) {
 					g.Expect(crosssg.Spec.ProviderConfigReference.Name).To(Equal(*tc.expectedProviderConfigRef))
 				}
 			} else {
-				g.Expect(err).To(HaveOccurred())
+				g.Expect(err).To(MatchError(tc.errorExpected))
 			}
-		})
-	}
-}
-
-func TestReconcileKopsControlPlane(t *testing.T) {
-
-	testCases := []struct {
-		description     string
-		input           *securitygroupv1alpha1.SecurityGroup
-		k8sObjects      []client.Object
-		isErrorExpected bool
-		validateOutput  func(sg securitygroupv1alpha1.SecurityGroup, crosssg *crossec2v1beta1.SecurityGroup) bool
-	}{
-		{
-			description: "should create a Crossplane SecurityGroup",
-			input: &securitygroupv1alpha1.SecurityGroup{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-security-group",
-				},
-				Spec: securitygroupv1alpha1.SecurityGroupSpec{
-					IngressRules: []securitygroupv1alpha1.IngressRule{
-						{
-							IPProtocol: "TCP",
-							FromPort:   40000,
-							ToPort:     60000,
-							AllowedCIDRBlocks: []string{
-								"0.0.0.0/0",
-							},
-						},
-					},
-					InfrastructureRef: &corev1.ObjectReference{
-						APIVersion: "controlplane.cluster.x-k8s.io/v1alpha1",
-						Kind:       "KopsControlPlane",
-						Name:       "test-cluster",
-						Namespace:  metav1.NamespaceDefault,
-					},
-				},
-			},
-			k8sObjects: []client.Object{
-				kmp, cluster, kcp,
-			},
-		},
-		{
-			description: "should fail when not finding Cluster",
-			input:       sg,
-			k8sObjects: []client.Object{
-				kmp, kcp,
-			},
-			isErrorExpected: true,
-		},
-		{
-			description: "should fail when not finding KopsControlPlane",
-			input:       sg,
-			k8sObjects: []client.Object{
-				kmp, cluster,
-			},
-			isErrorExpected: true,
-		},
-		{
-			description: "should add the pause annotation in the CSG when the WSG has the pause annotation",
-			input: &securitygroupv1alpha1.SecurityGroup{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-security-group",
-					Annotations: map[string]string{
-						AnnotationKeyReconciliationPaused: "true",
-					},
-				},
-				Spec: securitygroupv1alpha1.SecurityGroupSpec{
-					IngressRules: []securitygroupv1alpha1.IngressRule{
-						{
-							IPProtocol: "TCP",
-							FromPort:   40000,
-							ToPort:     60000,
-							AllowedCIDRBlocks: []string{
-								"0.0.0.0/0",
-							},
-						},
-					},
-					InfrastructureRef: &corev1.ObjectReference{
-						APIVersion: "controlplane.cluster.x-k8s.io/v1alpha1",
-						Kind:       "KopsControlPlane",
-						Name:       "test-cluster",
-						Namespace:  metav1.NamespaceDefault,
-					},
-				},
-			},
-			k8sObjects: []client.Object{
-				kmp, cluster, csg,
-			},
-			validateOutput: func(sg securitygroupv1alpha1.SecurityGroup, crosssg *crossec2v1beta1.SecurityGroup) bool {
-				return crosssg.GetAnnotations()[AnnotationKeyReconciliationPaused] == "true"
-			},
-		},
-	}
-	RegisterFailHandler(Fail)
-	g := NewWithT(t)
-
-	err := clusterv1beta1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = crossec2v1beta1.SchemeBuilder.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = securitygroupv1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = kinfrastructurev1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = kcontrolplanev1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	for _, tc := range testCases {
-		t.Run(tc.description, func(t *testing.T) {
-			ctx := context.TODO()
-
-			fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(tc.k8sObjects...).Build()
-			fakeEC2Client := &fakeec2.MockEC2Client{}
-			fakeEC2Client.MockDescribeVpcs = func(ctx context.Context, input *awsec2.DescribeVpcsInput, opts []func(*awsec2.Options)) (*awsec2.DescribeVpcsOutput, error) {
-				return &awsec2.DescribeVpcsOutput{
-					Vpcs: []ec2types.Vpc{
-						{
-							VpcId: aws.String("x.x.x.x"),
-						},
-					},
-				}, nil
-			}
-
-			fakeASGClient := &fakeasg.MockAutoScalingClient{}
-
-			recorder := record.NewFakeRecorder(5)
-
-			reconciler := SecurityGroupReconciler{
-				Client: fakeClient,
-				NewEC2ClientFactory: func(cfg aws.Config) ec2.EC2Client {
-					return fakeEC2Client
-				},
-				NewAutoScalingClientFactory: func(cfg aws.Config) autoscaling.AutoScalingClient {
-					return fakeASGClient
-				},
-				Recorder: recorder,
-			}
-
-			reconciliation := SecurityGroupReconciliation{
-				SecurityGroupReconciler: reconciler,
-				sg:                      tc.input,
-				kcp:                     kcp,
-				ec2Client:               reconciler.NewEC2ClientFactory(aws.Config{}),
-				log:                     ctrl.LoggerFrom(ctx),
-			}
-
-			err = reconciliation.reconcileKopsControlPlane(ctx)
-
-			if !tc.isErrorExpected {
-				if !errors.Is(err, ErrSecurityGroupNotAvailable) {
-					g.Expect(err).To(BeNil())
-				}
-
-				crosssg := &crossec2v1beta1.SecurityGroup{}
-				key := client.ObjectKey{
-					Name: sg.ObjectMeta.Name,
-				}
-				err = fakeClient.Get(ctx, key, crosssg)
-				g.Expect(err).To(BeNil())
-				g.Expect(crosssg).NotTo(BeNil())
-				if tc.validateOutput != nil {
-					g.Expect(tc.validateOutput(*sg, crosssg)).To(BeTrue())
-				}
-			} else {
-				g.Expect(err).ToNot(BeNil())
-			}
-
 		})
 	}
 }
@@ -617,43 +458,57 @@ func TestReconcileKopsControlPlane(t *testing.T) {
 func TestReconcileKopsMachinePool(t *testing.T) {
 
 	testCases := []struct {
-		description     string
-		k8sObjects      []client.Object
-		kmp             *kinfrastructurev1alpha1.KopsMachinePool
-		isErrorExpected bool
+		description          string
+		k8sObjects           []client.Object
+		kmp                  *kinfrastructurev1alpha1.KopsMachinePool
+		errorExpected        error
+		mockUpdateLaunchSpec func(context.Context, *oceanaws.UpdateLaunchSpecInput) (*oceanaws.UpdateLaunchSpecOutput, error)
 	}{
 		{
-			description: "should create a Crossplane SecurityGroup",
+			description: "should fail without secret credentials created",
 			k8sObjects: []client.Object{
 				kmp, cluster, kcp, sg,
 			},
-			kmp:             kmp,
-			isErrorExpected: false,
+			kmp:           kmp,
+			errorExpected: fmt.Errorf("failed to get secret: %w", apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "secrets"}, defaultSecret.Name)),
 		},
 		{
-			description: "should fail when not finding KopsMachinePool",
+			description: "should fail getting AWS account info",
 			k8sObjects: []client.Object{
-				cluster, kcp, sg,
+				kmp, cluster, sg, defaultSecret,
+				&kcontrolplanev1alpha1.KopsControlPlane{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: metav1.NamespaceDefault,
+						Name:      "test-cluster",
+					},
+					Spec: kcontrolplanev1alpha1.KopsControlPlaneSpec{
+						KopsClusterSpec: kopsapi.ClusterSpec{},
+						IdentityRef: &corev1.ObjectReference{
+							Name:      "default",
+							Namespace: "kubernetes-kops-operator-system",
+						},
+					},
+				},
 			},
-			kmp:             kmp,
-			isErrorExpected: true,
+			kmp:           kmp,
+			errorExpected: errors.New("security group not available"),
 		},
 		{
-			description: "should fail when not finding Cluster",
+			description: "should create a Crossplane SecurityGroup",
 			k8sObjects: []client.Object{
-				kmp, kcp, sg,
+				kmp, cluster, kcp, sg, defaultSecret,
 			},
-			kmp:             kmp,
-			isErrorExpected: true,
+			kmp: kmp,
 		},
 		{
-			description: "should fail when not finding KopsControlPlane",
+			description: "should return that csg isn't available",
 			k8sObjects: []client.Object{
-				kmp, cluster, sg,
+				kmp, cluster, kcp, sg, defaultSecret,
 			},
-			kmp:             kmp,
-			isErrorExpected: true,
+			kmp:           kmp,
+			errorExpected: ErrSecurityGroupNotAvailable,
 		},
+
 		{
 			description: "should reconcile without error with spotKMP",
 			k8sObjects: []client.Object{
@@ -661,9 +516,9 @@ func TestReconcileKopsMachinePool(t *testing.T) {
 				kcp,
 				sg,
 				csg,
+				defaultSecret,
 			},
-			kmp:             spotKMP,
-			isErrorExpected: false,
+			kmp: spotKMP,
 		},
 		{
 			description: "should fail with wrong spotKMP clusterName",
@@ -671,6 +526,7 @@ func TestReconcileKopsMachinePool(t *testing.T) {
 				cluster,
 				sg,
 				csg,
+				defaultSecret,
 				&kcontrolplanev1alpha1.KopsControlPlane{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: metav1.NamespaceDefault,
@@ -731,12 +587,13 @@ func TestReconcileKopsMachinePool(t *testing.T) {
 					},
 				},
 			},
-			isErrorExpected: true,
+			errorExpected: errors.New("error retrieving vng's from cluster: test-cluster-2"),
 		},
 		{
 			description: "should fail if cant match vng with kmp name",
 			k8sObjects: []client.Object{
 				cluster,
+				defaultSecret,
 				&securitygroupv1alpha1.SecurityGroup{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "test-security-group",
@@ -821,7 +678,31 @@ func TestReconcileKopsMachinePool(t *testing.T) {
 					},
 				},
 			},
-			isErrorExpected: true,
+			errorExpected: multierror.Append(errors.New("error no vng found with instance group name: test-kops-machine-pool-2")),
+		},
+		{
+			description: "should fail when failing to attach",
+			k8sObjects: []client.Object{
+				kmp, cluster, kcp, csg, sg, defaultSecret,
+			},
+			kmp: &kinfrastructurev1alpha1.KopsMachinePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: metav1.NamespaceDefault,
+					Name:      "test-kops-machine-pool",
+					Labels: map[string]string{
+						"cluster.x-k8s.io/cluster-name": "test-cluster",
+					},
+				},
+				Spec: kinfrastructurev1alpha1.KopsMachinePoolSpec{
+					ClusterName: "test-cluster",
+					KopsInstanceGroupSpec: kopsapi.InstanceGroupSpec{
+						NodeLabels: map[string]string{
+							"kops.k8s.io/instance-group-name": "test-ig",
+						},
+					},
+				},
+			},
+			errorExpected: multierror.Append(errors.New("failed to retrieve role from KopsMachinePool test-kops-machine-pool")),
 		},
 	}
 	RegisterFailHandler(Fail)
@@ -848,12 +729,64 @@ func TestReconcileKopsMachinePool(t *testing.T) {
 
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(tc.k8sObjects...).Build()
 			fakeEC2Client := &fakeec2.MockEC2Client{}
+			fakeEC2Client.MockDescribeInstances = func(ctx context.Context, input *awsec2.DescribeInstancesInput, opts []func(*awsec2.Options)) (*awsec2.DescribeInstancesOutput, error) {
+				return &awsec2.DescribeInstancesOutput{}, nil
+			}
 			fakeEC2Client.MockDescribeVpcs = func(ctx context.Context, input *awsec2.DescribeVpcsInput, opts []func(*awsec2.Options)) (*awsec2.DescribeVpcsOutput, error) {
 				return &awsec2.DescribeVpcsOutput{
 					Vpcs: []ec2types.Vpc{
 						{
 							VpcId: aws.String("x.x.x.x"),
 						},
+					},
+				}, nil
+			}
+			fakeEC2Client.MockDescribeLaunchTemplateVersions = func(ctx context.Context, params *awsec2.DescribeLaunchTemplateVersionsInput, optFns []func(*awsec2.Options)) (*awsec2.DescribeLaunchTemplateVersionsOutput, error) {
+				return &awsec2.DescribeLaunchTemplateVersionsOutput{
+					LaunchTemplateVersions: []ec2types.LaunchTemplateVersion{
+						{
+							LaunchTemplateId: params.LaunchTemplateId,
+							LaunchTemplateData: &ec2types.ResponseLaunchTemplateData{
+								NetworkInterfaces: []ec2types.LaunchTemplateInstanceNetworkInterfaceSpecification{
+									{
+										Groups: []string{
+											"sg-xxxx",
+										},
+									},
+								},
+							},
+						},
+					},
+				}, nil
+			}
+			fakeEC2Client.MockDescribeSecurityGroups = func(ctx context.Context, params *awsec2.DescribeSecurityGroupsInput, optFns []func(*awsec2.Options)) (*awsec2.DescribeSecurityGroupsOutput, error) {
+				return &awsec2.DescribeSecurityGroupsOutput{}, nil
+			}
+			fakeEC2Client.MockCreateLaunchTemplateVersion = func(ctx context.Context, params *awsec2.CreateLaunchTemplateVersionInput, optFns []func(*awsec2.Options)) (*awsec2.CreateLaunchTemplateVersionOutput, error) {
+				return &awsec2.CreateLaunchTemplateVersionOutput{
+					LaunchTemplateVersion: &ec2types.LaunchTemplateVersion{
+						VersionNumber: aws.Int64(1),
+					},
+				}, nil
+			}
+			fakeASGClient := &fakeasg.MockAutoScalingClient{}
+			fakeASGClient.MockDescribeAutoScalingGroups = func(ctx context.Context, params *awsautoscaling.DescribeAutoScalingGroupsInput, optFns []func(*awsautoscaling.Options)) (*awsautoscaling.DescribeAutoScalingGroupsOutput, error) {
+				return &awsautoscaling.DescribeAutoScalingGroupsOutput{
+					AutoScalingGroups: []autoscalingtypes.AutoScalingGroup{
+						{
+							AutoScalingGroupName: aws.String("testASG"),
+							LaunchTemplate: &autoscalingtypes.LaunchTemplateSpecification{
+								LaunchTemplateId: aws.String("lt-xxxx"),
+								Version:          aws.String("1"),
+							},
+						},
+					},
+				}, nil
+			}
+			fakeEC2Client.MockCreateLaunchTemplateVersion = func(ctx context.Context, params *awsec2.CreateLaunchTemplateVersionInput, optFns []func(*awsec2.Options)) (*awsec2.CreateLaunchTemplateVersionOutput, error) {
+				return &awsec2.CreateLaunchTemplateVersionOutput{
+					LaunchTemplateVersion: &ec2types.LaunchTemplateVersion{
+						VersionNumber: aws.Int64(1),
 					},
 				}, nil
 			}
@@ -887,8 +820,12 @@ func TestReconcileKopsMachinePool(t *testing.T) {
 					},
 				}, nil
 			}
-			fakeOceanClient.MockUpdateLaunchSpec = func(ctx context.Context, updateLaunchSpecInput *oceanaws.UpdateLaunchSpecInput) (*oceanaws.UpdateLaunchSpecOutput, error) {
-				return &oceanaws.UpdateLaunchSpecOutput{}, nil
+			if tc.mockUpdateLaunchSpec != nil {
+				fakeOceanClient.MockUpdateLaunchSpec = tc.mockUpdateLaunchSpec
+			} else {
+				fakeOceanClient.MockUpdateLaunchSpec = func(ctx context.Context, updateLaunchSpecInput *oceanaws.UpdateLaunchSpecInput) (*oceanaws.UpdateLaunchSpecOutput, error) {
+					return &oceanaws.UpdateLaunchSpecOutput{}, nil
+				}
 			}
 
 			recorder := record.NewFakeRecorder(5)
@@ -897,6 +834,9 @@ func TestReconcileKopsMachinePool(t *testing.T) {
 				Client: fakeClient,
 				NewEC2ClientFactory: func(cfg aws.Config) ec2.EC2Client {
 					return fakeEC2Client
+				},
+				NewAutoScalingClientFactory: func(cfg aws.Config) autoscaling.AutoScalingClient {
+					return fakeASGClient
 				},
 				NewOceanCloudProviderAWSFactory: func() spot.OceanClient {
 					return fakeOceanClient
@@ -908,13 +848,11 @@ func TestReconcileKopsMachinePool(t *testing.T) {
 				SecurityGroupReconciler: reconciler,
 				log:                     ctrl.LoggerFrom(ctx),
 				sg:                      sg,
-				kmp:                     tc.kmp,
 				ec2Client:               reconciler.NewEC2ClientFactory(aws.Config{}),
 			}
 
-			err = reconciliation.reconcileKopsMachinePool(ctx)
-
-			if !tc.isErrorExpected {
+			err = reconciliation.reconcileKopsMachinePool(ctx, kcp, *tc.kmp)
+			if tc.errorExpected == nil {
 				if !errors.Is(err, ErrSecurityGroupNotAvailable) {
 					g.Expect(err).To(BeNil())
 				}
@@ -928,7 +866,329 @@ func TestReconcileKopsMachinePool(t *testing.T) {
 				g.Expect(crosssg).NotTo(BeNil())
 
 			} else {
-				g.Expect(err).ToNot(BeNil())
+				g.Expect(tc.errorExpected).To(MatchError(err))
+			}
+		})
+	}
+}
+
+func TestAttachSGToVNG(t *testing.T) {
+	testCases := []struct {
+		description            string
+		k8sObjects             []client.Object
+		kmp                    *kinfrastructurev1alpha1.KopsMachinePool
+		csg                    *crossec2v1beta1.SecurityGroup
+		launchSpecs            []*oceanaws.LaunchSpec
+		instances              []ec2types.Instance
+		expectedSecurityGroups []string
+		errorExpected          error
+	}{
+		{
+			description: "should attach SG to VNG",
+			kmp:         spotKMP,
+			csg:         csg,
+			launchSpecs: []*oceanaws.LaunchSpec{
+				{
+					ID:   aws.String("1"),
+					Name: aws.String("test-vng"),
+					Labels: []*oceanaws.Label{
+						{
+							Key:   aws.String("kops.k8s.io/instance-group-name"),
+							Value: aws.String(spotKMP.Name),
+						},
+					},
+				},
+				{
+					ID:   aws.String("2"),
+					Name: aws.String("test-vng"),
+					Labels: []*oceanaws.Label{
+						{
+							Key:   aws.String("kops.k8s.io/instance-group-name"),
+							Value: aws.String("test-kops-machine-pool-2"),
+						},
+					},
+				},
+			},
+			expectedSecurityGroups: []string{"sg-1"},
+		},
+		{
+			description: "should do nothing when SG is already attached",
+			kmp:         spotKMP,
+			csg:         csg,
+			launchSpecs: []*oceanaws.LaunchSpec{
+				{
+					ID:   aws.String("1"),
+					Name: aws.String("test-vng"),
+					Labels: []*oceanaws.Label{
+						{
+							Key:   aws.String("kops.k8s.io/instance-group-name"),
+							Value: aws.String(spotKMP.Name),
+						},
+					},
+					SecurityGroupIDs: []string{
+						"sg-1",
+					},
+				},
+			},
+			expectedSecurityGroups: []string{"sg-1"},
+		},
+		{
+			description:   "should fail if cant match vng with kmp name",
+			kmp:           spotKMP,
+			csg:           csg,
+			launchSpecs:   []*oceanaws.LaunchSpec{},
+			errorExpected: fmt.Errorf("error no vng found with instance group name: %s", spotKMP.Name),
+		},
+		{
+			description: "should attach sg in the current vng instances",
+			kmp:         spotKMP,
+			csg:         csg,
+			instances: []ec2types.Instance{
+				{
+					InstanceId: aws.String("1"),
+				},
+			},
+			launchSpecs: []*oceanaws.LaunchSpec{
+				{
+					ID:   aws.String("1"),
+					Name: aws.String("test-vng"),
+					Labels: []*oceanaws.Label{
+						{
+							Key:   aws.String("kops.k8s.io/instance-group-name"),
+							Value: aws.String(spotKMP.Name),
+						},
+					},
+				},
+				{
+					ID:   aws.String("2"),
+					Name: aws.String("test-vng"),
+					Labels: []*oceanaws.Label{
+						{
+							Key:   aws.String("kops.k8s.io/instance-group-name"),
+							Value: aws.String("test-kops-machine-pool-2"),
+						},
+					},
+				},
+			},
+			expectedSecurityGroups: []string{"sg-1"},
+		},
+	}
+	RegisterFailHandler(Fail)
+	g := NewWithT(t)
+
+	err := crossec2v1beta1.SchemeBuilder.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = kinfrastructurev1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			ctx := context.TODO()
+
+			fakeEC2Client := &fakeec2.MockEC2Client{}
+			fakeEC2Client.MockDescribeInstances = func(ctx context.Context, input *awsec2.DescribeInstancesInput, opts []func(*awsec2.Options)) (*awsec2.DescribeInstancesOutput, error) {
+				return &awsec2.DescribeInstancesOutput{
+					Reservations: []ec2types.Reservation{
+						{
+							Instances: []ec2types.Instance{
+								{
+									InstanceId: aws.String("i-xxx"),
+								},
+							},
+						},
+					},
+				}, nil
+			}
+			fakeEC2Client.MockModifyInstanceAttribute = func(ctx context.Context, params *awsec2.ModifyInstanceAttributeInput, opts []func(*awsec2.Options)) (*awsec2.ModifyInstanceAttributeOutput, error) {
+				g.Expect(params.Groups).To(BeEquivalentTo(tc.expectedSecurityGroups))
+				return &awsec2.ModifyInstanceAttributeOutput{}, nil
+			}
+
+			fakeOceanClient := &fakeocean.MockOceanCloudProviderAWS{}
+			fakeOceanClient.MockUpdateLaunchSpec = func(ctx context.Context, updateLaunchSpecInput *oceanaws.UpdateLaunchSpecInput) (*oceanaws.UpdateLaunchSpecOutput, error) {
+				g.Expect(updateLaunchSpecInput.LaunchSpec.SecurityGroupIDs).To(BeEquivalentTo(tc.expectedSecurityGroups))
+				return &oceanaws.UpdateLaunchSpecOutput{}, nil
+			}
+			reconciler := SecurityGroupReconciler{
+				NewOceanCloudProviderAWSFactory: func() spot.OceanClient {
+					return fakeOceanClient
+				},
+			}
+
+			reconciliation := &SecurityGroupReconciliation{
+				SecurityGroupReconciler: reconciler,
+				ec2Client:               fakeEC2Client,
+				log:                     ctrl.LoggerFrom(ctx),
+			}
+
+			err = reconciliation.attachSGToVNG(ctx, fakeOceanClient, tc.launchSpecs, tc.kmp.Name, csg)
+			if tc.errorExpected == nil {
+				g.Expect(err).To(BeNil())
+			} else {
+				g.Expect(err).To(MatchError(tc.errorExpected))
+			}
+		})
+	}
+}
+
+func TestAttachSGToASG(t *testing.T) {
+	testCases := []struct {
+		description            string
+		k8sObjects             []client.Object
+		asgs                   []autoscalingtypes.AutoScalingGroup
+		instances              []ec2types.Instance
+		expectedSecurityGroups []string
+		errorExpected          error
+	}{
+		{
+			description: "should attach SecurityGroup to the ASG",
+			k8sObjects: []client.Object{
+				kmp, cluster, kcp, sg,
+			},
+			asgs: []autoscalingtypes.AutoScalingGroup{
+				{
+					AutoScalingGroupName: aws.String("test-asg"),
+					LaunchTemplate: &autoscalingtypes.LaunchTemplateSpecification{
+						LaunchTemplateId: aws.String("lt-xxxx"),
+						Version:          aws.String("1"),
+					},
+				},
+			},
+
+			expectedSecurityGroups: []string{"sg-xxxx", "sg-yyyy"},
+		},
+		{
+			description: "should attach SecurityGroup to the ASG instance",
+			k8sObjects: []client.Object{
+				kmp, cluster, kcp, sg,
+			},
+			asgs: []autoscalingtypes.AutoScalingGroup{
+				{
+					AutoScalingGroupName: aws.String("test-asg"),
+					LaunchTemplate: &autoscalingtypes.LaunchTemplateSpecification{
+						LaunchTemplateId: aws.String("lt-xxxx"),
+						Version:          aws.String("1"),
+					},
+					Instances: []autoscalingtypes.Instance{
+						{
+							InstanceId: aws.String("i-xxx"),
+						},
+					},
+				},
+			},
+			instances: []ec2types.Instance{
+				{
+					InstanceId: aws.String("i-xxx"),
+					SecurityGroups: []ec2types.GroupIdentifier{
+						{
+							GroupId: aws.String("sg-xxxx"),
+						},
+					},
+				},
+			},
+			expectedSecurityGroups: []string{"sg-xxxx", "sg-yyyy"},
+		},
+		{
+			description: "should fail when not finding asg",
+			k8sObjects: []client.Object{
+				kmp, cluster, kcp, sg,
+			},
+			errorExpected: errors.New("failed to retrieve AutoScalingGroup"),
+		},
+	}
+	RegisterFailHandler(Fail)
+	g := NewWithT(t)
+
+	err := clusterv1beta1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = crossec2v1beta1.SchemeBuilder.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = securitygroupv1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = kinfrastructurev1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = kcontrolplanev1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			ctx := context.TODO()
+
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(tc.k8sObjects...).Build()
+			fakeEC2Client := &fakeec2.MockEC2Client{}
+			fakeEC2Client.MockDescribeLaunchTemplateVersions = func(ctx context.Context, params *awsec2.DescribeLaunchTemplateVersionsInput, optFns []func(*awsec2.Options)) (*awsec2.DescribeLaunchTemplateVersionsOutput, error) {
+				return &awsec2.DescribeLaunchTemplateVersionsOutput{
+					LaunchTemplateVersions: []ec2types.LaunchTemplateVersion{
+						{
+							LaunchTemplateId: params.LaunchTemplateId,
+							LaunchTemplateData: &ec2types.ResponseLaunchTemplateData{
+								NetworkInterfaces: []ec2types.LaunchTemplateInstanceNetworkInterfaceSpecification{
+									{
+										Groups: []string{
+											"sg-xxxx",
+										},
+									},
+								},
+							},
+						},
+					},
+				}, nil
+			}
+			fakeEC2Client.MockModifyInstanceAttribute = func(ctx context.Context, params *awsec2.ModifyInstanceAttributeInput, opts []func(*awsec2.Options)) (*awsec2.ModifyInstanceAttributeOutput, error) {
+				g.Expect(params.Groups).To(BeEquivalentTo(tc.expectedSecurityGroups))
+				return &awsec2.ModifyInstanceAttributeOutput{}, nil
+			}
+			fakeEC2Client.MockDescribeInstances = func(ctx context.Context, input *awsec2.DescribeInstancesInput, opts []func(*awsec2.Options)) (*awsec2.DescribeInstancesOutput, error) {
+				return &awsec2.DescribeInstancesOutput{
+					Reservations: []ec2types.Reservation{
+						{
+							Instances: tc.instances,
+						},
+					},
+				}, nil
+			}
+			fakeEC2Client.MockCreateLaunchTemplateVersion = func(ctx context.Context, params *awsec2.CreateLaunchTemplateVersionInput, optFns []func(*awsec2.Options)) (*awsec2.CreateLaunchTemplateVersionOutput, error) {
+				g.Expect(params.LaunchTemplateData.NetworkInterfaces[0].Groups).To(BeEquivalentTo(tc.expectedSecurityGroups))
+				return &awsec2.CreateLaunchTemplateVersionOutput{
+					LaunchTemplateVersion: &ec2types.LaunchTemplateVersion{
+						LaunchTemplateId: params.LaunchTemplateId,
+						VersionNumber:    aws.Int64(2),
+					},
+				}, nil
+			}
+			fakeEC2Client.MockDescribeSecurityGroups = func(ctx context.Context, params *awsec2.DescribeSecurityGroupsInput, optFns []func(*awsec2.Options)) (*awsec2.DescribeSecurityGroupsOutput, error) {
+				return &awsec2.DescribeSecurityGroupsOutput{}, nil
+			}
+			fakeASGClient := &fakeasg.MockAutoScalingClient{}
+			fakeASGClient.MockDescribeAutoScalingGroups = func(ctx context.Context, params *awsautoscaling.DescribeAutoScalingGroupsInput, optFns []func(*awsautoscaling.Options)) (*awsautoscaling.DescribeAutoScalingGroupsOutput, error) {
+				return &awsautoscaling.DescribeAutoScalingGroupsOutput{
+					AutoScalingGroups: tc.asgs,
+				}, nil
+			}
+			fakeASGClient.MockUpdateAutoScalingGroup = func(ctx context.Context, params *awsautoscaling.UpdateAutoScalingGroupInput, optFns []func(*awsautoscaling.Options)) (*awsautoscaling.UpdateAutoScalingGroupOutput, error) {
+				Expect(*params.LaunchTemplate.Version).To(BeEquivalentTo("2"))
+				return &awsautoscaling.UpdateAutoScalingGroupOutput{}, nil
+			}
+			reconciler := SecurityGroupReconciler{
+				Client: fakeClient,
+			}
+
+			reconciliation := &SecurityGroupReconciliation{
+				SecurityGroupReconciler: reconciler,
+				asgClient:               fakeASGClient,
+				ec2Client:               fakeEC2Client,
+			}
+
+			err = reconciliation.attachSGToASG(ctx, "test-asg", "sg-yyyy")
+			if tc.errorExpected == nil {
+				g.Expect(err).To(BeNil())
+			} else {
+				g.Expect(err.Error()).To(ContainSubstring((tc.errorExpected.Error())))
 			}
 		})
 	}
@@ -938,47 +1198,48 @@ func TestReconcileDelete(t *testing.T) {
 	RegisterFailHandler(Fail)
 	g := NewWithT(t)
 
-	wsgMock := securitygroupv1alpha1.SecurityGroup{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-security-group",
-		},
-		Spec: securitygroupv1alpha1.SecurityGroupSpec{
-			IngressRules: []securitygroupv1alpha1.IngressRule{
-				{
-					IPProtocol: "TCP",
-					FromPort:   40000,
-					ToPort:     60000,
-					AllowedCIDRBlocks: []string{
-						"0.0.0.0/0",
-					},
-				},
-			},
-			InfrastructureRef: &corev1.ObjectReference{
-				APIVersion: "controlplane.cluster.x-k8s.io/v1alpha1",
-				Kind:       "KopsControlPlane",
-				Name:       "test-cluster",
-				Namespace:  metav1.NamespaceDefault,
-			},
-		},
-	}
-
-	csgMock := crossec2v1beta1.SecurityGroup{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-security-group",
-		},
-	}
-
 	testCases := []struct {
-		description string
-		k8sObjects  []client.Object
-		wsg         securitygroupv1alpha1.SecurityGroup
+		description   string
+		k8sObjects    []client.Object
+		sg            *securitygroupv1alpha1.SecurityGroup
+		expectedError error
 	}{
 		{
 			description: "should remove the crossplane security group",
 			k8sObjects: []client.Object{
-				&wsgMock, &csgMock, kcp, cluster,
+				sg, csg, kcp, kmp, cluster,
 			},
-			wsg: wsgMock,
+			sg: sg,
+		},
+		{
+			description: "should fail with infrastructureRef not supported",
+			k8sObjects: []client.Object{
+				sg, csg, kcp, kmp, cluster,
+			},
+			sg: &securitygroupv1alpha1.SecurityGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-security-group",
+				},
+				Spec: securitygroupv1alpha1.SecurityGroupSpec{
+					IngressRules: []securitygroupv1alpha1.IngressRule{
+						{
+							IPProtocol: "TCP",
+							FromPort:   40000,
+							ToPort:     60000,
+							AllowedCIDRBlocks: []string{
+								"0.0.0.0/0",
+							},
+						},
+					},
+					InfrastructureRef: &corev1.ObjectReference{
+						APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha1",
+						Kind:       "UnsupportedKind",
+						Name:       "test-kops-machine-pool",
+						Namespace:  metav1.NamespaceDefault,
+					},
+				},
+			},
+			expectedError: errors.New("infrastructureRef not supported"),
 		},
 	}
 
@@ -1002,10 +1263,34 @@ func TestReconcileDelete(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-
 			ctx := context.TODO()
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(tc.k8sObjects...).Build()
 			fakeEC2Client := &fakeec2.MockEC2Client{}
+			fakeEC2Client.MockCreateLaunchTemplateVersion = func(ctx context.Context, params *awsec2.CreateLaunchTemplateVersionInput, optFns []func(*awsec2.Options)) (*awsec2.CreateLaunchTemplateVersionOutput, error) {
+				return &awsec2.CreateLaunchTemplateVersionOutput{
+					LaunchTemplateVersion: &ec2types.LaunchTemplateVersion{
+						VersionNumber: aws.Int64(1),
+					},
+				}, nil
+			}
+			fakeEC2Client.MockDescribeLaunchTemplateVersions = func(ctx context.Context, params *awsec2.DescribeLaunchTemplateVersionsInput, optFns []func(*awsec2.Options)) (*awsec2.DescribeLaunchTemplateVersionsOutput, error) {
+				return &awsec2.DescribeLaunchTemplateVersionsOutput{
+					LaunchTemplateVersions: []ec2types.LaunchTemplateVersion{
+						{
+							LaunchTemplateId: params.LaunchTemplateId,
+							LaunchTemplateData: &ec2types.ResponseLaunchTemplateData{
+								NetworkInterfaces: []ec2types.LaunchTemplateInstanceNetworkInterfaceSpecification{
+									{
+										Groups: []string{
+											"sg-yyyy",
+										},
+									},
+								},
+							},
+						},
+					},
+				}, nil
+			}
 			fakeEC2Client.MockDescribeVpcs = func(ctx context.Context, input *awsec2.DescribeVpcsInput, opts []func(*awsec2.Options)) (*awsec2.DescribeVpcsOutput, error) {
 				return &awsec2.DescribeVpcsOutput{
 					Vpcs: []ec2types.Vpc{
@@ -1045,797 +1330,41 @@ func TestReconcileDelete(t *testing.T) {
 				log:                     ctrl.LoggerFrom(ctx),
 				ec2Client:               reconciler.NewEC2ClientFactory(aws.Config{}),
 				asgClient:               reconciler.NewAutoScalingClientFactory(aws.Config{}),
-				sg:                      &tc.wsg,
+				sg:                      tc.sg,
 			}
 
-			_, err = reconciliation.reconcileDelete(ctx, &tc.wsg)
-			g.Expect(err).ToNot(HaveOccurred())
-
-			deletedCSG := &crossec2v1beta1.SecurityGroup{}
-			key := client.ObjectKey{
-				Name: tc.wsg.Name,
-			}
-			err = fakeClient.Get(ctx, key, deletedCSG)
-			g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
-		})
-	}
-}
-
-func TestAttachSGToASG(t *testing.T) {
-	testCases := []map[string]interface{}{
-		{
-			"description": "should attach SecurityGroup to the ASG",
-			"k8sObjects": []client.Object{
-				kmp, cluster, kcp, sg,
-			},
-			"isErrorExpected": false,
-		},
-	}
-	RegisterFailHandler(Fail)
-	g := NewWithT(t)
-
-	err := clusterv1beta1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = crossec2v1beta1.SchemeBuilder.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = securitygroupv1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = kinfrastructurev1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = kcontrolplanev1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	for _, tc := range testCases {
-		t.Run(tc["description"].(string), func(t *testing.T) {
-			ctx := context.TODO()
-
-			k8sObjects := tc["k8sObjects"].([]client.Object)
-
-			fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(k8sObjects...).Build()
-			fakeEC2Client := &fakeec2.MockEC2Client{}
-			fakeEC2Client.MockDescribeLaunchTemplateVersions = func(ctx context.Context, params *awsec2.DescribeLaunchTemplateVersionsInput, optFns []func(*awsec2.Options)) (*awsec2.DescribeLaunchTemplateVersionsOutput, error) {
-				return &awsec2.DescribeLaunchTemplateVersionsOutput{
-					LaunchTemplateVersions: []ec2types.LaunchTemplateVersion{
-						{
-							LaunchTemplateId: params.LaunchTemplateId,
-							LaunchTemplateData: &ec2types.ResponseLaunchTemplateData{
-								NetworkInterfaces: []ec2types.LaunchTemplateInstanceNetworkInterfaceSpecification{
-									{
-										Groups: []string{
-											"sg-xxxx",
-										},
-									},
-								},
-							},
-						},
-					},
-				}, nil
-			}
-			fakeEC2Client.MockCreateLaunchTemplateVersion = func(ctx context.Context, params *awsec2.CreateLaunchTemplateVersionInput, optFns []func(*awsec2.Options)) (*awsec2.CreateLaunchTemplateVersionOutput, error) {
-				return &awsec2.CreateLaunchTemplateVersionOutput{
-					LaunchTemplateVersion: &ec2types.LaunchTemplateVersion{
-						VersionNumber: aws.Int64(1),
-					},
-				}, nil
-			}
-			fakeEC2Client.MockModifyLaunchTemplate = func(ctx context.Context, params *awsec2.ModifyLaunchTemplateInput, optFns []func(*awsec2.Options)) (*awsec2.ModifyLaunchTemplateOutput, error) {
-				return &awsec2.ModifyLaunchTemplateOutput{
-					LaunchTemplate: &ec2types.LaunchTemplate{},
-				}, nil
-			}
-			fakeEC2Client.MockDescribeSecurityGroups = func(ctx context.Context, params *awsec2.DescribeSecurityGroupsInput, optFns []func(*awsec2.Options)) (*awsec2.DescribeSecurityGroupsOutput, error) {
-				return &awsec2.DescribeSecurityGroupsOutput{}, nil
-			}
-			fakeASGClient := &fakeasg.MockAutoScalingClient{}
-			fakeASGClient.MockDescribeAutoScalingGroups = func(ctx context.Context, params *awsautoscaling.DescribeAutoScalingGroupsInput, optFns []func(*awsautoscaling.Options)) (*awsautoscaling.DescribeAutoScalingGroupsOutput, error) {
-				return &awsautoscaling.DescribeAutoScalingGroupsOutput{
-					AutoScalingGroups: []autoscalingtypes.AutoScalingGroup{
-						{
-							AutoScalingGroupName: aws.String("testASG"),
-							LaunchTemplate: &autoscalingtypes.LaunchTemplateSpecification{
-								LaunchTemplateId: aws.String("lt-xxxx"),
-								Version:          aws.String("1"),
-							},
-						},
-					},
-				}, nil
-			}
-			reconciler := SecurityGroupReconciler{
-				Client: fakeClient,
-			}
-
-			reconciliation := &SecurityGroupReconciliation{
-				SecurityGroupReconciler: reconciler,
-				asgClient:               fakeASGClient,
-				ec2Client:               fakeEC2Client,
-			}
-
-			err = reconciliation.attachSGToASG(ctx, "asgName", "sg-yyyy")
-			if !tc["isErrorExpected"].(bool) {
-				g.Expect(err).To(BeNil())
-
-			} else {
-				g.Expect(err).ToNot(BeNil())
-			}
-		})
-	}
-}
-
-func TestAttachSGToVNG(t *testing.T) {
-	testCases := []struct {
-		description     string
-		k8sObjects      []client.Object
-		kmp             *kinfrastructurev1alpha1.KopsMachinePool
-		csg             *crossec2v1beta1.SecurityGroup
-		launchSpecs     []*oceanaws.LaunchSpec
-		isErrorExpected bool
-		updateMockError bool
-	}{
-		{
-			description: "should attach SG to VNG",
-			kmp:         spotKMP,
-			csg:         csg,
-			launchSpecs: []*oceanaws.LaunchSpec{
-				{
-					ID:   aws.String("1"),
-					Name: aws.String("test-vng"),
-					Labels: []*oceanaws.Label{
-						{
-							Key:   aws.String("kops.k8s.io/instance-group-name"),
-							Value: aws.String(spotKMP.Name),
-						},
-					},
-				},
-			},
-			isErrorExpected: false,
-		},
-		{
-			description: "should return nil if sg is already attached",
-			kmp:         spotKMP,
-			csg:         csg,
-			launchSpecs: []*oceanaws.LaunchSpec{
-				{
-					ID:   aws.String("1"),
-					Name: aws.String("test-vng"),
-					Labels: []*oceanaws.Label{
-						{
-							Key:   aws.String("kops.k8s.io/instance-group-name"),
-							Value: aws.String(spotKMP.Name),
-						},
-					},
-					SecurityGroupIDs: []string{
-						"sg-1",
-					},
-				},
-			},
-			isErrorExpected: false,
-		},
-		{
-			description:     "should fail if cant match vng with kmp name",
-			kmp:             spotKMP,
-			csg:             csg,
-			launchSpecs:     []*oceanaws.LaunchSpec{},
-			isErrorExpected: true,
-		},
-		{
-			description: "should fail if update return an error",
-			kmp:         spotKMP,
-			csg:         csg,
-			launchSpecs: []*oceanaws.LaunchSpec{
-				{
-					ID:   aws.String("1"),
-					Name: aws.String("test-vng"),
-					Labels: []*oceanaws.Label{
-						{
-							Key:   aws.String("kops.k8s.io/instance-group-name"),
-							Value: aws.String(spotKMP.Name),
-						},
-					},
-				},
-			},
-			updateMockError: true,
-			isErrorExpected: true,
-		},
-	}
-	RegisterFailHandler(Fail)
-	g := NewWithT(t)
-
-	err := crossec2v1beta1.SchemeBuilder.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = kinfrastructurev1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	for _, tc := range testCases {
-		t.Run(tc.description, func(t *testing.T) {
-			ctx := context.TODO()
-
-			fakeOceanClient := &fakeocean.MockOceanCloudProviderAWS{}
-			if tc.updateMockError {
-				fakeOceanClient.MockUpdateLaunchSpec = func(ctx context.Context, updateLaunchSpecInput *oceanaws.UpdateLaunchSpecInput) (*oceanaws.UpdateLaunchSpecOutput, error) {
-					return nil, fmt.Errorf("error")
+			_, err = reconciliation.reconcileDelete(ctx, tc.sg)
+			if tc.expectedError == nil {
+				g.Expect(err).ToNot(HaveOccurred())
+				deletedSG := &crossec2v1beta1.SecurityGroup{}
+				key := client.ObjectKey{
+					Name: tc.sg.Name,
 				}
-			} else {
-				fakeOceanClient.MockUpdateLaunchSpec = func(ctx context.Context, updateLaunchSpecInput *oceanaws.UpdateLaunchSpecInput) (*oceanaws.UpdateLaunchSpecOutput, error) {
-					return &oceanaws.UpdateLaunchSpecOutput{}, nil
+				err = fakeClient.Get(ctx, key, deletedSG)
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+
+				deletedCSG := &crossec2v1beta1.SecurityGroup{}
+				key = client.ObjectKey{
+					Name: tc.sg.Name,
 				}
-			}
-			reconciler := SecurityGroupReconciler{
-				NewOceanCloudProviderAWSFactory: func() spot.OceanClient {
-					return fakeOceanClient
-				},
-			}
-
-			reconciliation := &SecurityGroupReconciliation{
-				SecurityGroupReconciler: reconciler,
-				log:                     ctrl.LoggerFrom(ctx),
-			}
-
-			err = reconciliation.attachSGToVNG(ctx, fakeOceanClient, tc.launchSpecs, tc.kmp.Name, csg)
-			if tc.isErrorExpected {
-				g.Expect(err).ToNot(BeNil())
+				err = fakeClient.Get(ctx, key, deletedCSG)
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
 			} else {
-				g.Expect(err).To(BeNil())
+				g.Expect(err).To(MatchError(tc.expectedError))
 			}
 		})
 	}
 }
 
-func TestDeleteSGFromASG(t *testing.T) {
-	sg2 := &securitygroupv1alpha1.SecurityGroup{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-security-group2",
-		},
-		Spec: securitygroupv1alpha1.SecurityGroupSpec{
-			IngressRules: []securitygroupv1alpha1.IngressRule{
-				{
-					IPProtocol: "TCP",
-					FromPort:   -1,
-					ToPort:     -1,
-					AllowedCIDRBlocks: []string{
-						"0.0.0.0/0",
-					},
-				},
-			},
-			InfrastructureRef: &corev1.ObjectReference{
-				APIVersion: "controlplane.cluster.x-k8s.io/v1alpha1",
-				Kind:       "KopsControlPlane",
-				Name:       "test-cluster2",
-				Namespace:  metav1.NamespaceDefault,
-			},
-		},
-	}
-
-	kmp2 := &kinfrastructurev1alpha1.KopsMachinePool{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: metav1.NamespaceDefault,
-			Name:      "test-kops-machine-pool2",
-			Labels: map[string]string{
-				"cluster.x-k8s.io/cluster-name": "test-cluster2",
-			},
-		},
-		Spec: kinfrastructurev1alpha1.KopsMachinePoolSpec{
-			ClusterName: "test-cluster2",
-			KopsInstanceGroupSpec: kopsapi.InstanceGroupSpec{
-				NodeLabels: map[string]string{
-					"kops.k8s.io/instance-group-name": "test-ig",
-					"kops.k8s.io/instance-group-role": "Node",
-				},
-			},
-		},
-	}
-
-	kcp2 := &kcontrolplanev1alpha1.KopsControlPlane{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: metav1.NamespaceDefault,
-			Name:      "test-cluster2",
-		},
-		Spec: kcontrolplanev1alpha1.KopsControlPlaneSpec{
-			KopsClusterSpec: kopsapi.ClusterSpec{
-				Subnets: []kopsapi.ClusterSubnetSpec{
-					{
-						Name: "test-subnet",
-						CIDR: "0.0.0.0/26",
-						Zone: "us-east-1d",
-					},
-				},
-			},
-		},
-	}
-
-	testCases := []map[string]interface{}{
-		{
-			"description": "should delete kops machine pool SecurityGroup to the ASG",
-			"k8sObjects": []client.Object{
-				kmp, cluster, kcp, sg,
-			},
-			"isErrorExpected": false,
-			"mutateFn": func(sg *securitygroupv1alpha1.SecurityGroup, kmp *kinfrastructurev1alpha1.KopsMachinePool, kcp *kcontrolplanev1alpha1.KopsControlPlane) {
-			},
-		},
-		{
-			"description": "should delete kops machine pool SecurityGroup to the ASG",
-			"k8sObjects": []client.Object{
-				kmp, cluster, kcp, sg, kcp2, kmp2, sg2,
-			},
-			"isErrorExpected": false,
-			"mutateFn": func(sgi *securitygroupv1alpha1.SecurityGroup, kmpi *kinfrastructurev1alpha1.KopsMachinePool, kcpi *kcontrolplanev1alpha1.KopsControlPlane) {
-				sg = sgi
-
-				kmp = kmpi
-
-				kcp = kcpi
-			},
-		},
-	}
-	RegisterFailHandler(Fail)
-	g := NewWithT(t)
-
-	err := clusterv1beta1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = crossec2v1beta1.SchemeBuilder.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = securitygroupv1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = kinfrastructurev1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = kcontrolplanev1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	for _, tc := range testCases {
-		t.Run(tc["description"].(string), func(t *testing.T) {
-			ctx := context.TODO()
-
-			k8sObjects := tc["k8sObjects"].([]client.Object)
-
-			fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(k8sObjects...).Build()
-			fakeEC2Client := &fakeec2.MockEC2Client{}
-			fakeEC2Client.MockDescribeVpcs = func(ctx context.Context, input *awsec2.DescribeVpcsInput, opts []func(*awsec2.Options)) (*awsec2.DescribeVpcsOutput, error) {
-				return &awsec2.DescribeVpcsOutput{
-					Vpcs: []ec2types.Vpc{
-						{
-							VpcId: aws.String("x.x.x.x"),
-						},
-					},
-				}, nil
-			}
-			fakeEC2Client.MockDescribeLaunchTemplateVersions = func(ctx context.Context, params *awsec2.DescribeLaunchTemplateVersionsInput, optFns []func(*awsec2.Options)) (*awsec2.DescribeLaunchTemplateVersionsOutput, error) {
-				return &awsec2.DescribeLaunchTemplateVersionsOutput{
-					LaunchTemplateVersions: []ec2types.LaunchTemplateVersion{
-						{
-							LaunchTemplateId: params.LaunchTemplateId,
-							LaunchTemplateData: &ec2types.ResponseLaunchTemplateData{
-								NetworkInterfaces: []ec2types.LaunchTemplateInstanceNetworkInterfaceSpecification{
-									{
-										Groups: []string{
-											"sg-xxxx",
-										},
-									},
-								},
-							},
-						},
-					},
-				}, nil
-			}
-			fakeEC2Client.MockCreateLaunchTemplateVersion = func(ctx context.Context, params *awsec2.CreateLaunchTemplateVersionInput, optFns []func(*awsec2.Options)) (*awsec2.CreateLaunchTemplateVersionOutput, error) {
-				return &awsec2.CreateLaunchTemplateVersionOutput{
-					LaunchTemplateVersion: &ec2types.LaunchTemplateVersion{
-						VersionNumber: aws.Int64(1),
-					},
-				}, nil
-			}
-			fakeEC2Client.MockModifyLaunchTemplate = func(ctx context.Context, params *awsec2.ModifyLaunchTemplateInput, optFns []func(*awsec2.Options)) (*awsec2.ModifyLaunchTemplateOutput, error) {
-				return &awsec2.ModifyLaunchTemplateOutput{
-					LaunchTemplate: &ec2types.LaunchTemplate{},
-				}, nil
-			}
-			fakeEC2Client.MockDescribeSecurityGroups = func(ctx context.Context, params *awsec2.DescribeSecurityGroupsInput, optFns []func(*awsec2.Options)) (*awsec2.DescribeSecurityGroupsOutput, error) {
-				return &awsec2.DescribeSecurityGroupsOutput{}, nil
-			}
-			fakeASGClient := &fakeasg.MockAutoScalingClient{}
-			fakeASGClient.MockDescribeAutoScalingGroups = func(ctx context.Context, params *awsautoscaling.DescribeAutoScalingGroupsInput, optFns []func(*awsautoscaling.Options)) (*awsautoscaling.DescribeAutoScalingGroupsOutput, error) {
-				return &awsautoscaling.DescribeAutoScalingGroupsOutput{
-					AutoScalingGroups: []autoscalingtypes.AutoScalingGroup{
-						{
-							AutoScalingGroupName: aws.String("testASG"),
-							LaunchTemplate: &autoscalingtypes.LaunchTemplateSpecification{
-								LaunchTemplateId: aws.String("lt-xxxx"),
-								Version:          aws.String("1"),
-							},
-						},
-					},
-				}, nil
-			}
-			reconciler := SecurityGroupReconciler{
-				Client: fakeClient,
-				NewEC2ClientFactory: func(cfg aws.Config) ec2.EC2Client {
-					return fakeEC2Client
-				},
-				NewAutoScalingClientFactory: func(cfg aws.Config) autoscaling.AutoScalingClient {
-					return fakeASGClient
-				},
-			}
-			tc["mutateFn"].(func(sgi *securitygroupv1alpha1.SecurityGroup, kmpi *kinfrastructurev1alpha1.KopsMachinePool, kcpi *kcontrolplanev1alpha1.KopsControlPlane))(sg, kmp, kcp)
-
-			reconciliation := &SecurityGroupReconciliation{
-				SecurityGroupReconciler: reconciler,
-				log:                     ctrl.LoggerFrom(ctx),
-				asgClient:               fakeASGClient,
-				ec2Client:               fakeEC2Client,
-			}
-
-			err = reconciliation.deleteSGFromASG(ctx, sg, csg)
-			if !tc["isErrorExpected"].(bool) {
-				g.Expect(err).To(BeNil())
-
-			} else {
-				g.Expect(err).ToNot(BeNil())
-			}
-		})
-	}
-}
-
-func TestDeleteSGFromKopsControlPlaneASGs(t *testing.T) {
+func TestDetachSGFromVNG(t *testing.T) {
 	testCases := []struct {
-		description     string
-		k8sObjects      []client.Object
-		kcp             *kcontrolplanev1alpha1.KopsControlPlane
-		csg             *crossec2v1beta1.SecurityGroup
-		launchSpecs     []*oceanaws.LaunchSpec
-		isErrorExpected bool
-		updateMockError bool
-	}{
-		{
-			description: "should detach kops machine pool SecurityGroup from ASG",
-			kcp:         kcp,
-			k8sObjects: []client.Object{
-				kmp, cluster, kcp, sg, csg,
-			},
-			isErrorExpected: false,
-		},
-		{
-			description: "should detach kops machine pool SecurityGroup from VNG",
-			kcp:         kcp,
-			k8sObjects: []client.Object{
-				spotKMP, cluster, kcp, sg, csg,
-			},
-			isErrorExpected: false,
-		},
-	}
-	RegisterFailHandler(Fail)
-	g := NewWithT(t)
-
-	err := clusterv1beta1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = crossec2v1beta1.SchemeBuilder.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = securitygroupv1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = kinfrastructurev1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = kcontrolplanev1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	for _, tc := range testCases {
-		t.Run(tc.description, func(t *testing.T) {
-			ctx := context.TODO()
-
-			fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(tc.k8sObjects...).Build()
-			fakeEC2Client := &fakeec2.MockEC2Client{}
-			fakeEC2Client.MockDescribeVpcs = func(ctx context.Context, input *awsec2.DescribeVpcsInput, opts []func(*awsec2.Options)) (*awsec2.DescribeVpcsOutput, error) {
-				return &awsec2.DescribeVpcsOutput{
-					Vpcs: []ec2types.Vpc{
-						{
-							VpcId: aws.String("x.x.x.x"),
-						},
-					},
-				}, nil
-			}
-			fakeEC2Client.MockDescribeLaunchTemplateVersions = func(ctx context.Context, params *awsec2.DescribeLaunchTemplateVersionsInput, optFns []func(*awsec2.Options)) (*awsec2.DescribeLaunchTemplateVersionsOutput, error) {
-				return &awsec2.DescribeLaunchTemplateVersionsOutput{
-					LaunchTemplateVersions: []ec2types.LaunchTemplateVersion{
-						{
-							LaunchTemplateId: params.LaunchTemplateId,
-							LaunchTemplateData: &ec2types.ResponseLaunchTemplateData{
-								NetworkInterfaces: []ec2types.LaunchTemplateInstanceNetworkInterfaceSpecification{
-									{
-										Groups: []string{
-											"sg-xxxx",
-										},
-									},
-								},
-							},
-						},
-					},
-				}, nil
-			}
-			fakeEC2Client.MockCreateLaunchTemplateVersion = func(ctx context.Context, params *awsec2.CreateLaunchTemplateVersionInput, optFns []func(*awsec2.Options)) (*awsec2.CreateLaunchTemplateVersionOutput, error) {
-				return &awsec2.CreateLaunchTemplateVersionOutput{
-					LaunchTemplateVersion: &ec2types.LaunchTemplateVersion{
-						VersionNumber: aws.Int64(1),
-					},
-				}, nil
-			}
-			fakeEC2Client.MockModifyLaunchTemplate = func(ctx context.Context, params *awsec2.ModifyLaunchTemplateInput, optFns []func(*awsec2.Options)) (*awsec2.ModifyLaunchTemplateOutput, error) {
-				return &awsec2.ModifyLaunchTemplateOutput{
-					LaunchTemplate: &ec2types.LaunchTemplate{},
-				}, nil
-			}
-			fakeEC2Client.MockDescribeSecurityGroups = func(ctx context.Context, params *awsec2.DescribeSecurityGroupsInput, optFns []func(*awsec2.Options)) (*awsec2.DescribeSecurityGroupsOutput, error) {
-				return &awsec2.DescribeSecurityGroupsOutput{}, nil
-			}
-			fakeASGClient := &fakeasg.MockAutoScalingClient{}
-			fakeASGClient.MockDescribeAutoScalingGroups = func(ctx context.Context, params *awsautoscaling.DescribeAutoScalingGroupsInput, optFns []func(*awsautoscaling.Options)) (*awsautoscaling.DescribeAutoScalingGroupsOutput, error) {
-				return &awsautoscaling.DescribeAutoScalingGroupsOutput{
-					AutoScalingGroups: []autoscalingtypes.AutoScalingGroup{
-						{
-							AutoScalingGroupName: aws.String("testASG"),
-							LaunchTemplate: &autoscalingtypes.LaunchTemplateSpecification{
-								LaunchTemplateId: aws.String("lt-xxxx"),
-								Version:          aws.String("1"),
-							},
-						},
-					},
-				}, nil
-			}
-			fakeOceanClient := &fakeocean.MockOceanCloudProviderAWS{}
-
-			fakeOceanClient.MockListClusters = func(ctx context.Context, listClusterInput *oceanaws.ListClustersInput) (*oceanaws.ListClustersOutput, error) {
-				return &oceanaws.ListClustersOutput{
-					Clusters: []*oceanaws.Cluster{
-						{
-							ID:                  aws.String("o-1"),
-							ControllerClusterID: aws.String("test-cluster"),
-						},
-					},
-				}, nil
-			}
-			fakeOceanClient.MockListLaunchSpecs = func(ctx context.Context, listLaunchSpecsInput *oceanaws.ListLaunchSpecsInput) (*oceanaws.ListLaunchSpecsOutput, error) {
-				return &oceanaws.ListLaunchSpecsOutput{
-					LaunchSpecs: []*oceanaws.LaunchSpec{
-						{
-							ID:      aws.String("1"),
-							Name:    aws.String("vng-test"),
-							OceanID: aws.String("o-1"),
-							Labels: []*oceanaws.Label{
-								{
-									Key:   aws.String("kops.k8s.io/instance-group-name"),
-									Value: aws.String("test-kops-machine-pool"),
-								},
-							},
-						},
-					},
-				}, nil
-			}
-			fakeOceanClient.MockUpdateLaunchSpec = func(ctx context.Context, updateLaunchSpecInput *oceanaws.UpdateLaunchSpecInput) (*oceanaws.UpdateLaunchSpecOutput, error) {
-				return &oceanaws.UpdateLaunchSpecOutput{}, nil
-			}
-
-			reconciler := SecurityGroupReconciler{
-				Client: fakeClient,
-				NewOceanCloudProviderAWSFactory: func() spot.OceanClient {
-					return fakeOceanClient
-				},
-			}
-
-			reconciliation := &SecurityGroupReconciliation{
-				SecurityGroupReconciler: reconciler,
-				ec2Client:               fakeEC2Client,
-				asgClient:               fakeASGClient,
-			}
-
-			err = reconciliation.deleteSGFromKopsControlPlaneASGs(ctx, sg, csg, tc.kcp)
-			if !tc.isErrorExpected {
-				g.Expect(err).To(BeNil())
-
-			} else {
-				g.Expect(err).ToNot(BeNil())
-			}
-		})
-	}
-}
-
-func TestDeleteSGFromKopsMachinePoolASG(t *testing.T) {
-	testCases := []struct {
-		description     string
-		k8sObjects      []client.Object
-		kmp             *kinfrastructurev1alpha1.KopsMachinePool
-		csg             *crossec2v1beta1.SecurityGroup
-		launchSpecs     []*oceanaws.LaunchSpec
-		isErrorExpected bool
-		updateMockError bool
-	}{
-		{
-			description: "should detach SG from ASG",
-			kmp:         kmp,
-			csg:         csg,
-			k8sObjects: []client.Object{
-				cluster,
-				kmp,
-				csg,
-				sg,
-				kcp,
-			},
-			isErrorExpected: false,
-		},
-		{
-			description: "should detach SG from VNG",
-			kmp:         spotKMP,
-			csg:         csg,
-			k8sObjects: []client.Object{
-				cluster,
-				spotKMP,
-				csg,
-				sg,
-				kcp,
-			},
-			isErrorExpected: false,
-		},
-	}
-	RegisterFailHandler(Fail)
-	g := NewWithT(t)
-
-	err := clusterv1beta1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = crossec2v1beta1.SchemeBuilder.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = securitygroupv1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = kinfrastructurev1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = kcontrolplanev1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	for _, tc := range testCases {
-		t.Run(tc.description, func(t *testing.T) {
-			ctx := context.TODO()
-
-			fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(tc.k8sObjects...).Build()
-			fakeEC2Client := &fakeec2.MockEC2Client{}
-			fakeEC2Client.MockDescribeVpcs = func(ctx context.Context, input *awsec2.DescribeVpcsInput, opts []func(*awsec2.Options)) (*awsec2.DescribeVpcsOutput, error) {
-				return &awsec2.DescribeVpcsOutput{
-					Vpcs: []ec2types.Vpc{
-						{
-							VpcId: aws.String("x.x.x.x"),
-						},
-					},
-				}, nil
-			}
-			fakeEC2Client.MockDescribeLaunchTemplateVersions = func(ctx context.Context, params *awsec2.DescribeLaunchTemplateVersionsInput, optFns []func(*awsec2.Options)) (*awsec2.DescribeLaunchTemplateVersionsOutput, error) {
-				return &awsec2.DescribeLaunchTemplateVersionsOutput{
-					LaunchTemplateVersions: []ec2types.LaunchTemplateVersion{
-						{
-							LaunchTemplateId: params.LaunchTemplateId,
-							LaunchTemplateData: &ec2types.ResponseLaunchTemplateData{
-								NetworkInterfaces: []ec2types.LaunchTemplateInstanceNetworkInterfaceSpecification{
-									{
-										Groups: []string{
-											"sg-xxxx",
-										},
-									},
-								},
-							},
-						},
-					},
-				}, nil
-			}
-			fakeEC2Client.MockCreateLaunchTemplateVersion = func(ctx context.Context, params *awsec2.CreateLaunchTemplateVersionInput, optFns []func(*awsec2.Options)) (*awsec2.CreateLaunchTemplateVersionOutput, error) {
-				return &awsec2.CreateLaunchTemplateVersionOutput{
-					LaunchTemplateVersion: &ec2types.LaunchTemplateVersion{
-						VersionNumber: aws.Int64(1),
-					},
-				}, nil
-			}
-			fakeEC2Client.MockModifyLaunchTemplate = func(ctx context.Context, params *awsec2.ModifyLaunchTemplateInput, optFns []func(*awsec2.Options)) (*awsec2.ModifyLaunchTemplateOutput, error) {
-				return &awsec2.ModifyLaunchTemplateOutput{
-					LaunchTemplate: &ec2types.LaunchTemplate{},
-				}, nil
-			}
-			fakeEC2Client.MockDescribeSecurityGroups = func(ctx context.Context, params *awsec2.DescribeSecurityGroupsInput, optFns []func(*awsec2.Options)) (*awsec2.DescribeSecurityGroupsOutput, error) {
-				return &awsec2.DescribeSecurityGroupsOutput{}, nil
-			}
-			fakeASGClient := &fakeasg.MockAutoScalingClient{}
-			fakeASGClient.MockDescribeAutoScalingGroups = func(ctx context.Context, params *awsautoscaling.DescribeAutoScalingGroupsInput, optFns []func(*awsautoscaling.Options)) (*awsautoscaling.DescribeAutoScalingGroupsOutput, error) {
-				return &awsautoscaling.DescribeAutoScalingGroupsOutput{
-					AutoScalingGroups: []autoscalingtypes.AutoScalingGroup{
-						{
-							AutoScalingGroupName: aws.String("testASG"),
-							LaunchTemplate: &autoscalingtypes.LaunchTemplateSpecification{
-								LaunchTemplateId: aws.String("lt-xxxx"),
-								Version:          aws.String("1"),
-							},
-						},
-					},
-				}, nil
-			}
-			fakeOceanClient := &fakeocean.MockOceanCloudProviderAWS{}
-
-			fakeOceanClient.MockListClusters = func(ctx context.Context, listClusterInput *oceanaws.ListClustersInput) (*oceanaws.ListClustersOutput, error) {
-				return &oceanaws.ListClustersOutput{
-					Clusters: []*oceanaws.Cluster{
-						{
-							ID:                  aws.String("o-1"),
-							ControllerClusterID: aws.String("test-cluster"),
-						},
-					},
-				}, nil
-			}
-			fakeOceanClient.MockListLaunchSpecs = func(ctx context.Context, listLaunchSpecsInput *oceanaws.ListLaunchSpecsInput) (*oceanaws.ListLaunchSpecsOutput, error) {
-				return &oceanaws.ListLaunchSpecsOutput{
-					LaunchSpecs: []*oceanaws.LaunchSpec{
-						{
-							ID:      aws.String("1"),
-							Name:    aws.String("vng-test"),
-							OceanID: aws.String("o-1"),
-							Labels: []*oceanaws.Label{
-								{
-									Key:   aws.String("kops.k8s.io/instance-group-name"),
-									Value: aws.String("test-kops-machine-pool"),
-								},
-							},
-						},
-					},
-				}, nil
-			}
-			fakeOceanClient.MockUpdateLaunchSpec = func(ctx context.Context, updateLaunchSpecInput *oceanaws.UpdateLaunchSpecInput) (*oceanaws.UpdateLaunchSpecOutput, error) {
-				return &oceanaws.UpdateLaunchSpecOutput{}, nil
-			}
-
-			reconciler := SecurityGroupReconciler{
-				Client: fakeClient,
-				NewEC2ClientFactory: func(cfg aws.Config) ec2.EC2Client {
-					return fakeEC2Client
-				},
-				NewAutoScalingClientFactory: func(cfg aws.Config) autoscaling.AutoScalingClient {
-					return fakeASGClient
-				},
-				NewOceanCloudProviderAWSFactory: func() spot.OceanClient {
-					return fakeOceanClient
-				},
-			}
-
-			reconciliation := &SecurityGroupReconciliation{
-				SecurityGroupReconciler: reconciler,
-				log:                     ctrl.LoggerFrom(ctx),
-				asgClient:               fakeASGClient,
-				ec2Client:               fakeEC2Client,
-			}
-
-			err = reconciliation.deleteSGFromKopsMachinePoolASG(ctx, sg, tc.csg, tc.kmp)
-			if !tc.isErrorExpected {
-				g.Expect(err).To(BeNil())
-
-			} else {
-				g.Expect(err).ToNot(BeNil())
-			}
-		})
-	}
-}
-
-func TestDettachSGFromVNG(t *testing.T) {
-	testCases := []struct {
-		description     string
-		kmp             *kinfrastructurev1alpha1.KopsMachinePool
-		csg             *crossec2v1beta1.SecurityGroup
-		launchSpecs     []*oceanaws.LaunchSpec
-		isErrorExpected bool
-		updateMockError bool
+		description            string
+		kmp                    *kinfrastructurev1alpha1.KopsMachinePool
+		csg                    *crossec2v1beta1.SecurityGroup
+		launchSpecs            []*oceanaws.LaunchSpec
+		expectedSecurityGroups []string
+		errorExpected          error
+		updateMockError        bool
 	}{
 		{
 			description: "should detach SG-1 from VNG",
@@ -1857,10 +1386,10 @@ func TestDettachSGFromVNG(t *testing.T) {
 					},
 				},
 			},
-			isErrorExpected: false,
+			expectedSecurityGroups: []string{"sg-2"},
 		},
 		{
-			description: "should return nil if sg is not attached",
+			description: "should do nothing if sg is not attached without error",
 			kmp:         spotKMP,
 			csg:         csg,
 			launchSpecs: []*oceanaws.LaunchSpec{
@@ -1878,14 +1407,14 @@ func TestDettachSGFromVNG(t *testing.T) {
 					},
 				},
 			},
-			isErrorExpected: false,
+			expectedSecurityGroups: []string{"sg-2"},
 		},
 		{
-			description:     "should fail if cant match vng with kmp name",
-			kmp:             spotKMP,
-			csg:             csg,
-			launchSpecs:     []*oceanaws.LaunchSpec{},
-			isErrorExpected: true,
+			description:   "should fail if cant match vng with kmp name",
+			kmp:           spotKMP,
+			csg:           csg,
+			launchSpecs:   []*oceanaws.LaunchSpec{},
+			errorExpected: fmt.Errorf("error no vng found with instance group name:"),
 		},
 		{
 			description: "should fail if update return an error",
@@ -1908,7 +1437,7 @@ func TestDettachSGFromVNG(t *testing.T) {
 				},
 			},
 			updateMockError: true,
-			isErrorExpected: true,
+			errorExpected:   fmt.Errorf("error updating ocean cluster launch spec:"),
 		},
 	}
 	RegisterFailHandler(Fail)
@@ -1931,6 +1460,7 @@ func TestDettachSGFromVNG(t *testing.T) {
 				}
 			} else {
 				fakeOceanClient.MockUpdateLaunchSpec = func(ctx context.Context, updateLaunchSpecInput *oceanaws.UpdateLaunchSpecInput) (*oceanaws.UpdateLaunchSpecOutput, error) {
+					g.Expect(updateLaunchSpecInput.LaunchSpec.SecurityGroupIDs).To(Equal(tc.expectedSecurityGroups))
 					return &oceanaws.UpdateLaunchSpecOutput{}, nil
 				}
 			}
@@ -1946,23 +1476,113 @@ func TestDettachSGFromVNG(t *testing.T) {
 			}
 
 			err = reconciliation.detachSGFromVNG(ctx, fakeOceanClient, tc.launchSpecs, tc.kmp.Name, csg)
-			if tc.isErrorExpected {
-				g.Expect(err).ToNot(BeNil())
-			} else {
+			if tc.errorExpected == nil {
 				g.Expect(err).To(BeNil())
+			} else {
+				g.Expect(err.Error()).To(ContainSubstring(tc.errorExpected.Error()))
 			}
 		})
 	}
 }
 
-func TestDettachSGFromASG(t *testing.T) {
-	testCases := []map[string]interface{}{
+func TestDetachSGFromASG(t *testing.T) {
+	testCases := []struct {
+		description            string
+		k8sObjects             []client.Object
+		launchTemplateVersions []ec2types.LaunchTemplateVersion
+		asgs                   []autoscalingtypes.AutoScalingGroup
+		errorExpected          error
+		expectedSecurityGroups []string
+	}{
 		{
-			"description": "should dettach SecurityGroup to the ASG",
-			"k8sObjects": []client.Object{
+			description: "should detach SecurityGroup from the ASG",
+			asgs: []autoscalingtypes.AutoScalingGroup{
+				{
+					AutoScalingGroupName: aws.String("test-asg"),
+					LaunchTemplate: &autoscalingtypes.LaunchTemplateSpecification{
+						LaunchTemplateId: aws.String("lt-xxxx"),
+						Version:          aws.String("1"),
+					},
+				},
+			},
+			launchTemplateVersions: []ec2types.LaunchTemplateVersion{
+				{
+					LaunchTemplateId: aws.String("lt-xxxx"),
+					LaunchTemplateData: &ec2types.ResponseLaunchTemplateData{
+						NetworkInterfaces: []ec2types.LaunchTemplateInstanceNetworkInterfaceSpecification{
+							{
+								Groups: []string{
+									"sg-1",
+								},
+							},
+						},
+					},
+				},
+			},
+			k8sObjects: []client.Object{
 				kmp, cluster, kcp, sg,
 			},
-			"isErrorExpected": false,
+		},
+		{
+			description: "should do nothing when SecurityGroup is already detached",
+			asgs: []autoscalingtypes.AutoScalingGroup{
+				{
+					AutoScalingGroupName: aws.String("test-asg"),
+					LaunchTemplate: &autoscalingtypes.LaunchTemplateSpecification{
+						LaunchTemplateId: aws.String("lt-xxxx"),
+						Version:          aws.String("1"),
+					},
+				},
+			},
+			launchTemplateVersions: []ec2types.LaunchTemplateVersion{
+				{
+					LaunchTemplateId: aws.String("lt-xxxx"),
+					LaunchTemplateData: &ec2types.ResponseLaunchTemplateData{
+						NetworkInterfaces: []ec2types.LaunchTemplateInstanceNetworkInterfaceSpecification{
+							{
+								Groups: []string{
+									"sg-1",
+								},
+							},
+						},
+					},
+				},
+			},
+			k8sObjects: []client.Object{
+				kmp, cluster, kcp, sg,
+			},
+		},
+		{
+			description: "should return err when failing to retrieve ASG",
+			asgs: []autoscalingtypes.AutoScalingGroup{
+				{
+					AutoScalingGroupName: aws.String("test-asg-2"),
+					LaunchTemplate: &autoscalingtypes.LaunchTemplateSpecification{
+						LaunchTemplateId: aws.String("lt-xxxx"),
+						Version:          aws.String("1"),
+					},
+				},
+			},
+			k8sObjects: []client.Object{
+				kmp, cluster, kcp, sg,
+			},
+			errorExpected: fmt.Errorf("ASG Not Found"),
+		},
+		{
+			description: "should return err when failing to retrieve launch template version",
+			asgs: []autoscalingtypes.AutoScalingGroup{
+				{
+					AutoScalingGroupName: aws.String("test-asg"),
+					LaunchTemplate: &autoscalingtypes.LaunchTemplateSpecification{
+						LaunchTemplateId: aws.String("lt-xxxx"),
+						Version:          aws.String("1"),
+					},
+				},
+			},
+			k8sObjects: []client.Object{
+				kmp, cluster, kcp, sg,
+			},
+			errorExpected: fmt.Errorf("Launch Template Not Found"),
 		},
 	}
 	RegisterFailHandler(Fail)
@@ -1984,41 +1604,28 @@ func TestDettachSGFromASG(t *testing.T) {
 	Expect(err).NotTo(HaveOccurred())
 
 	for _, tc := range testCases {
-		t.Run(tc["description"].(string), func(t *testing.T) {
+		t.Run(tc.description, func(t *testing.T) {
 			ctx := context.TODO()
 
-			k8sObjects := tc["k8sObjects"].([]client.Object)
-
-			fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(k8sObjects...).Build()
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(tc.k8sObjects...).Build()
 			fakeEC2Client := &fakeec2.MockEC2Client{}
 			fakeEC2Client.MockDescribeLaunchTemplateVersions = func(ctx context.Context, params *awsec2.DescribeLaunchTemplateVersionsInput, optFns []func(*awsec2.Options)) (*awsec2.DescribeLaunchTemplateVersionsOutput, error) {
+				launchTemplateVersions := []ec2types.LaunchTemplateVersion{}
+				for _, lt := range tc.launchTemplateVersions {
+					if *lt.LaunchTemplateId == *params.LaunchTemplateId {
+						launchTemplateVersions = append(launchTemplateVersions, lt)
+					}
+				}
 				return &awsec2.DescribeLaunchTemplateVersionsOutput{
-					LaunchTemplateVersions: []ec2types.LaunchTemplateVersion{
-						{
-							LaunchTemplateId: params.LaunchTemplateId,
-							LaunchTemplateData: &ec2types.ResponseLaunchTemplateData{
-								NetworkInterfaces: []ec2types.LaunchTemplateInstanceNetworkInterfaceSpecification{
-									{
-										Groups: []string{
-											"sg-yyyy",
-										},
-									},
-								},
-							},
-						},
-					},
+					LaunchTemplateVersions: launchTemplateVersions,
 				}, nil
 			}
 			fakeEC2Client.MockCreateLaunchTemplateVersion = func(ctx context.Context, params *awsec2.CreateLaunchTemplateVersionInput, optFns []func(*awsec2.Options)) (*awsec2.CreateLaunchTemplateVersionOutput, error) {
+				g.Expect(params.LaunchTemplateData.SecurityGroupIds).To(Equal(tc.expectedSecurityGroups))
 				return &awsec2.CreateLaunchTemplateVersionOutput{
 					LaunchTemplateVersion: &ec2types.LaunchTemplateVersion{
 						VersionNumber: aws.Int64(1),
 					},
-				}, nil
-			}
-			fakeEC2Client.MockModifyLaunchTemplate = func(ctx context.Context, params *awsec2.ModifyLaunchTemplateInput, optFns []func(*awsec2.Options)) (*awsec2.ModifyLaunchTemplateOutput, error) {
-				return &awsec2.ModifyLaunchTemplateOutput{
-					LaunchTemplate: &ec2types.LaunchTemplate{},
 				}, nil
 			}
 			fakeEC2Client.MockDescribeSecurityGroups = func(ctx context.Context, params *awsec2.DescribeSecurityGroupsInput, optFns []func(*awsec2.Options)) (*awsec2.DescribeSecurityGroupsOutput, error) {
@@ -2026,16 +1633,14 @@ func TestDettachSGFromASG(t *testing.T) {
 			}
 			fakeASGClient := &fakeasg.MockAutoScalingClient{}
 			fakeASGClient.MockDescribeAutoScalingGroups = func(ctx context.Context, params *awsautoscaling.DescribeAutoScalingGroupsInput, optFns []func(*awsautoscaling.Options)) (*awsautoscaling.DescribeAutoScalingGroupsOutput, error) {
+				asgs := []autoscalingtypes.AutoScalingGroup{}
+				for _, asg := range tc.asgs {
+					if *asg.AutoScalingGroupName == params.AutoScalingGroupNames[0] {
+						asgs = append(asgs, asg)
+					}
+				}
 				return &awsautoscaling.DescribeAutoScalingGroupsOutput{
-					AutoScalingGroups: []autoscalingtypes.AutoScalingGroup{
-						{
-							AutoScalingGroupName: aws.String("testASG"),
-							LaunchTemplate: &autoscalingtypes.LaunchTemplateSpecification{
-								LaunchTemplateId: aws.String("lt-xxxx"),
-								Version:          aws.String("1"),
-							},
-						},
-					},
+					AutoScalingGroups: asgs,
 				}, nil
 			}
 			reconciler := SecurityGroupReconciler{
@@ -2052,12 +1657,12 @@ func TestDettachSGFromASG(t *testing.T) {
 				ec2Client:               fakeEC2Client,
 			}
 
-			err = reconciliation.detachSGFromASG(ctx, "testASG", "sg-yyyy")
-			if !tc["isErrorExpected"].(bool) {
+			err = reconciliation.detachSGFromASG(ctx, "test-asg", "sg-1")
+			if tc.errorExpected == nil {
 				g.Expect(err).To(BeNil())
-
 			} else {
-				g.Expect(err).ToNot(BeNil())
+				g.Expect(err.Error()).To(ContainSubstring(tc.errorExpected.Error()))
+
 			}
 		})
 	}
@@ -2069,7 +1674,7 @@ func TestSecurityGroupStatus(t *testing.T) {
 		k8sObjects                    []client.Object
 		mockDescribeAutoScalingGroups func(ctx context.Context, params *awsautoscaling.DescribeAutoScalingGroupsInput, optFns []func(*awsautoscaling.Options)) (*awsautoscaling.DescribeAutoScalingGroupsOutput, error)
 		conditionsToAssert            []*clusterv1beta1.Condition
-		isErrorExpected               bool
+		errorExpected                 error
 		expectedReadiness             bool
 	}{
 		{
@@ -2082,7 +1687,6 @@ func TestSecurityGroupStatus(t *testing.T) {
 				conditions.TrueCondition(securitygroupv1alpha1.CrossplaneResourceReadyCondition),
 				conditions.TrueCondition(securitygroupv1alpha1.SecurityGroupAttachedCondition),
 			},
-			isErrorExpected:   false,
 			expectedReadiness: true,
 		},
 		{
@@ -2116,7 +1720,6 @@ func TestSecurityGroupStatus(t *testing.T) {
 					"error message",
 				),
 			},
-			isErrorExpected: false,
 		},
 		{
 			description: "should mark attach condition as false when failed to attach",
@@ -2134,7 +1737,7 @@ func TestSecurityGroupStatus(t *testing.T) {
 					clusterv1beta1.ConditionSeverityError,
 					"some error when attaching asg"),
 			},
-			isErrorExpected: true,
+			errorExpected: errors.New("failed to retrieve AutoScalingGroup"),
 		},
 	}
 
@@ -2196,11 +1799,6 @@ func TestSecurityGroupStatus(t *testing.T) {
 					},
 				}, nil
 			}
-			fakeEC2Client.MockModifyLaunchTemplate = func(ctx context.Context, params *awsec2.ModifyLaunchTemplateInput, optFns []func(*awsec2.Options)) (*awsec2.ModifyLaunchTemplateOutput, error) {
-				return &awsec2.ModifyLaunchTemplateOutput{
-					LaunchTemplate: &ec2types.LaunchTemplate{},
-				}, nil
-			}
 			fakeEC2Client.MockDescribeSecurityGroups = func(ctx context.Context, params *awsec2.DescribeSecurityGroupsInput, optFns []func(*awsec2.Options)) (*awsec2.DescribeSecurityGroupsOutput, error) {
 				return &awsec2.DescribeSecurityGroupsOutput{}, nil
 			}
@@ -2225,7 +1823,8 @@ func TestSecurityGroupStatus(t *testing.T) {
 			}
 
 			reconciler := &SecurityGroupReconciler{
-				Client: fakeClient,
+				Client:   fakeClient,
+				Recorder: record.NewFakeRecorder(5),
 				NewAutoScalingClientFactory: func(cfg aws.Config) autoscaling.AutoScalingClient {
 					return fakeASGClient
 				},
@@ -2240,12 +1839,11 @@ func TestSecurityGroupStatus(t *testing.T) {
 				},
 			})
 
-			if tc.isErrorExpected {
-				g.Expect(err).To(HaveOccurred())
+			if tc.errorExpected != nil {
+				g.Expect(err.Error()).To(ContainSubstring(tc.errorExpected.Error()))
 			} else {
-				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(err).ToNot(HaveOccurred())
 			}
-
 			sg = &securitygroupv1alpha1.SecurityGroup{}
 			key := client.ObjectKey{
 				Name: "test-security-group",

--- a/pkg/aws/ec2/fake/vpc.go
+++ b/pkg/aws/ec2/fake/vpc.go
@@ -8,15 +8,20 @@ import (
 
 type MockEC2Client struct {
 	MockDescribeVpcs                   func(ctx context.Context, input *ec2.DescribeVpcsInput, opts []func(*ec2.Options)) (*ec2.DescribeVpcsOutput, error)
+	MockDescribeInstances              func(ctx context.Context, input *ec2.DescribeInstancesInput, opts []func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error)
 	MockDescribeLaunchTemplateVersions func(ctx context.Context, params *ec2.DescribeLaunchTemplateVersionsInput, optFns []func(*ec2.Options)) (*ec2.DescribeLaunchTemplateVersionsOutput, error)
 	MockCreateLaunchTemplateVersion    func(ctx context.Context, params *ec2.CreateLaunchTemplateVersionInput, optFns []func(*ec2.Options)) (*ec2.CreateLaunchTemplateVersionOutput, error)
-	MockModifyLaunchTemplate           func(ctx context.Context, params *ec2.ModifyLaunchTemplateInput, optFns []func(*ec2.Options)) (*ec2.ModifyLaunchTemplateOutput, error)
+	MockModifyInstanceAttribute        func(ctx context.Context, params *ec2.ModifyInstanceAttributeInput, opts []func(*ec2.Options)) (*ec2.ModifyInstanceAttributeOutput, error)
 	MockDescribeSecurityGroups         func(ctx context.Context, params *ec2.DescribeSecurityGroupsInput, optFns []func(*ec2.Options)) (*ec2.DescribeSecurityGroupsOutput, error)
 	MockDescribeRouteTables            func(ctx context.Context, params *ec2.DescribeRouteTablesInput, optFns []func(*ec2.Options)) (*ec2.DescribeRouteTablesOutput, error)
 }
 
 func (m *MockEC2Client) DescribeVpcs(ctx context.Context, input *ec2.DescribeVpcsInput, opts ...func(*ec2.Options)) (*ec2.DescribeVpcsOutput, error) {
 	return m.MockDescribeVpcs(ctx, input, opts)
+}
+
+func (m *MockEC2Client) DescribeInstances(ctx context.Context, input *ec2.DescribeInstancesInput, opts ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error) {
+	return m.MockDescribeInstances(ctx, input, opts)
 }
 
 func (m *MockEC2Client) DescribeLaunchTemplateVersions(ctx context.Context, params *ec2.DescribeLaunchTemplateVersionsInput, opts ...func(*ec2.Options)) (*ec2.DescribeLaunchTemplateVersionsOutput, error) {
@@ -27,8 +32,8 @@ func (m *MockEC2Client) CreateLaunchTemplateVersion(ctx context.Context, params 
 	return m.MockCreateLaunchTemplateVersion(ctx, params, opts)
 }
 
-func (m *MockEC2Client) ModifyLaunchTemplate(ctx context.Context, params *ec2.ModifyLaunchTemplateInput, opts ...func(*ec2.Options)) (*ec2.ModifyLaunchTemplateOutput, error) {
-	return m.MockModifyLaunchTemplate(ctx, params, opts)
+func (m *MockEC2Client) ModifyInstanceAttribute(ctx context.Context, params *ec2.ModifyInstanceAttributeInput, opts ...func(*ec2.Options)) (*ec2.ModifyInstanceAttributeOutput, error) {
+	return m.MockModifyInstanceAttribute(ctx, params, opts)
 }
 
 func (m *MockEC2Client) DescribeSecurityGroups(ctx context.Context, params *ec2.DescribeSecurityGroupsInput, opts ...func(*ec2.Options)) (*ec2.DescribeSecurityGroupsOutput, error) {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -26,7 +26,7 @@ func awsConfigForCredential(ctx context.Context, region string, accessKey string
 }
 
 // returns (secretName, awsConfig, err)
-func AwsCredentialsFromKcp(ctx context.Context, c client.Client, kcp *kcontrolplanev1alpha1.KopsControlPlane) (string, *aws.Config, error) {
+func AWSCredentialsFromKCP(ctx context.Context, c client.Client, kcp *kcontrolplanev1alpha1.KopsControlPlane) (string, *aws.Config, error) {
 	subnet, err := kops.GetSubnetFromKopsControlPlane(kcp)
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to get subnet from kcp: %w", err)


### PR DESCRIPTION
The goal of this PR is to add support to attach the Security Group to the current compute instances that belongs to the instance groups