### PR TITLE
fix: also uses the cluster name when getting the vpcid

### DIFF
--- a/controllers/clustermesh/clustermesh_controller.go
+++ b/controllers/clustermesh/clustermesh_controller.go
@@ -561,7 +561,7 @@ func PopulateClusterSpec(r *ClusterMeshReconciliation, ctx context.Context, clus
 		return clusterSpec, err
 	}
 
-	vpcId, err := ec2.GetVPCIdFromCIDR(ctx, r.ec2Client, r.kcp.Spec.KopsClusterSpec.NetworkCIDR)
+	vpcId, err := ec2.GetVPCIdWithCIDRAndClusterName(ctx, r.ec2Client, r.kcp.Name, r.kcp.Spec.KopsClusterSpec.NetworkCIDR)
 	if err != nil {
 		return clusterSpec, err
 	}

--- a/controllers/securitygroup/securitygroup_controller.go
+++ b/controllers/securitygroup/securitygroup_controller.go
@@ -117,7 +117,7 @@ func (r *SecurityGroupReconciliation) getAWSAccountInfo(ctx context.Context, kcp
 		return aws.String(""), aws.String(""), err
 	}
 
-	vpcId, err := ec2.GetVPCIdFromCIDR(ctx, r.ec2Client, kcp.Spec.KopsClusterSpec.NetworkCIDR)
+	vpcId, err := ec2.GetVPCIdWithCIDRAndClusterName(ctx, r.ec2Client, kcp.Name, kcp.Spec.KopsClusterSpec.NetworkCIDR)
 	if err != nil {
 		return aws.String(""), aws.String(""), err
 	}

--- a/pkg/aws/ec2/vpc.go
+++ b/pkg/aws/ec2/vpc.go
@@ -101,15 +101,20 @@ func GetReservationsUsingFilters(ctx context.Context, ec2Client EC2Client, filte
 	return instances.Reservations, nil
 }
 
-func GetVPCIdFromCIDR(ctx context.Context, ec2Client EC2Client, CIDR string) (*string, error) {
+func GetVPCIdWithCIDRAndClusterName(ctx context.Context, ec2Client EC2Client, clusterName, CIDR string) (*string, error) {
 
-	filter := "cidr"
 	result, err := ec2Client.DescribeVpcs(ctx, &ec2.DescribeVpcsInput{
 		Filters: []ec2types.Filter{
 			{
-				Name: &filter,
+				Name: aws.String("cidr"),
 				Values: []string{
 					CIDR,
+				},
+			},
+			{
+				Name: aws.String("tag:KubernetesCluster"),
+				Values: []string{
+					clusterName,
 				},
 			},
 		},


### PR DESCRIPTION
Currently we retrieve the vpcid from AWS using the CIDR from the kcp object, the problem is that some vpcs have the same CIDR resulting in retrieving th id from the wrong vpc. The goals of this PR is to solve this by incrementing the filter of the describe with the Kubernetes cluster name to avoid this scenario