### PR TITLE
chore: update deletionPolicy of vpcpeeringconnections to Delete

### DIFF
--- a/pkg/crossplane/crossplane.go
+++ b/pkg/crossplane/crossplane.go
@@ -54,7 +54,6 @@ func NewCrossPlaneVPCPeeringConnection(clustermesh *clustermeshv1alpha1.ClusterM
 				},
 			},
 			ResourceSpec: crossplanev1.ResourceSpec{
-				DeletionPolicy: crossplanev1.DeletionOrphan,
 				ProviderConfigReference: &crossplanev1.Reference{
 					Name: providerConfigName,
 				},


### PR DESCRIPTION
The goal of this PR is to update the deletionPolicy of the vpcpeering resources to Delete instead of Orphan