### PR TITLE
Feat: cleanup ig resources

### DIFF
--- a/internal/controller/ec2.aws/securitygroup_controller.go
+++ b/internal/controller/ec2.aws/securitygroup_controller.go
@@ -54,8 +54,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var (
@@ -156,17 +154,14 @@ func (c *SecurityGroupReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}()
 
 	if r.sg.Spec.InfrastructureRef == nil {
-		r.sg.ObjectMeta.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+		// r.sg.ObjectMeta.DeletionTimestamp = &metav1.Time{Time: time.Now()}
 		// return resultDefault, fmt.Errorf("infrastructureRef not supported")
+		return r.reconcileDelete(ctx, r.sg)
 	} else {
 		err := r.retrieveInfraRefInfo(ctx)
 		if err != nil {
 			return resultError, err
 		}
-	}
-
-	if !r.sg.ObjectMeta.DeletionTimestamp.IsZero() {
-		return r.reconcileDelete(ctx, r.sg)
 	}
 
 	return r.reconcileNormal(ctx)

--- a/internal/controller/ec2.aws/securitygroup_controller.go
+++ b/internal/controller/ec2.aws/securitygroup_controller.go
@@ -134,12 +134,24 @@ func (c *SecurityGroupReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	r.log.Info(fmt.Sprintf("starting reconcile loop for %s", r.sg.ObjectMeta.GetName()))
 
 	defer func() {
-		if err := r.Status().Update(ctx, r.sg); err != nil {
-			r.Recorder.Eventf(r.sg, corev1.EventTypeWarning, "FailedToUpdateStatus", "failed to update security group status %s: %s", r.sg.Name, err)
+		securityGroupHelper := r.sg.DeepCopy()
+		if err := r.Update(ctx, r.sg); err != nil {
+			r.Recorder.Eventf(r.sg, corev1.EventTypeWarning, "FailedToUpdate", "failed to update security group %s: %s", r.sg.Name, err)
 			if rerr == nil {
 				rerr = err
 			}
 		}
+
+		if securityGroupHelper.ObjectMeta.DeletionTimestamp.IsZero() {
+			r.sg.Status = securityGroupHelper.Status
+			if err := r.Status().Update(ctx, r.sg); err != nil {
+				r.Recorder.Eventf(r.sg, corev1.EventTypeWarning, "FailedToUpdateStatus", "failed to update security group status %s: %s", r.sg.Name, err)
+				if rerr == nil {
+					rerr = err
+				}
+			}
+		}
+
 		r.log.Info(fmt.Sprintf("finished reconcile loop for %s", r.sg.ObjectMeta.GetName()))
 	}()
 

--- a/internal/controller/ec2.aws/securitygroup_controller_test.go
+++ b/internal/controller/ec2.aws/securitygroup_controller_test.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsautoscaling "github.com/aws/aws-sdk-go-v2/service/autoscaling"
@@ -349,42 +348,6 @@ func TestSecurityGroupReconciler(t *testing.T) {
 				},
 			},
 			errorExpected: errors.New("infrastructureRef not supported"),
-		},
-		{
-			description: "should remove SecurityGroup with DeletionTimestamp",
-			k8sObjects: []client.Object{
-				kmp, cluster, kcp, defaultSecret, csg,
-				&securitygroupv1alpha2.SecurityGroup{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:              "test-security-group",
-						DeletionTimestamp: &metav1.Time{Time: time.Now()},
-						Finalizers: []string{
-							"securitygroup.wildlife.infrastructure.io",
-						},
-					},
-					Spec: securitygroupv1alpha2.SecurityGroupSpec{
-						IngressRules: []securitygroupv1alpha2.IngressRule{
-							{
-								IPProtocol: "TCP",
-								FromPort:   40000,
-								ToPort:     60000,
-								AllowedCIDRBlocks: []string{
-									"0.0.0.0/0",
-								},
-							},
-						},
-						InfrastructureRef: []*corev1.ObjectReference{
-							{
-								APIVersion: "controlplane.cluster.x-k8s.io/v1alpha1",
-								Kind:       "KopsControlPlane",
-								Name:       "test-cluster",
-								Namespace:  metav1.NamespaceDefault,
-							},
-						},
-					},
-				},
-			},
-			expectedDeletion: true,
 		},
 		{
 			description: "should create a SecurityGroup with the same providerConfigName",

--- a/internal/controller/ec2.aws/securitygroup_controller_test.go
+++ b/internal/controller/ec2.aws/securitygroup_controller_test.go
@@ -736,11 +736,11 @@ func TestSecurityGroupReconciler(t *testing.T) {
 				if tc.expectedSG != nil {
 					tmpSG := &securitygroupv1alpha2.SecurityGroup{}
 					key := client.ObjectKey{
-						Name: *&tc.expectedSG.Name,
+						Name: tc.expectedSG.Name,
 					}
 					err = fakeClient.Get(ctx, key, tmpSG)
 					g.Expect(err).To(BeNil())
-					g.Expect(tmpSG.ObjectMeta.Name).To(Equal(*&tc.expectedSG.ObjectMeta.Name))
+					g.Expect(tmpSG.ObjectMeta.Name).To(Equal(tc.expectedSG.ObjectMeta.Name))
 					g.Expect(len(tmpSG.Spec.InfrastructureRef)).To(Equal(len(tc.expectedSG.Spec.InfrastructureRef)))
 				}
 


### PR DESCRIPTION
## Context

When the clusters/igs are deleted, we must also clean up the resources that reference those objects like security groups. SGs have a list of referenced infrastructure resources which the reconciliation loop needs to ensure is up to date with the actual existing resources.

## Solution

During the reconciliation loop, our provider checks the existence of every resource referenced by the SG. The resources that doesn't exist anymore are removed from the list and if by the end of this process there are no more resources being referenced, the SG is deleted. These changes also covers the use case when we just want to delete the SG keeping the machine pools referenced.