### PR TITLE
Fix: change sg finalizer suffix to sgID

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: tfgco/kubernetes-crossplane-infrastructure-operator
-  newTag: v0.7.1-alpha
+  newTag: v0.8.3-alpha

--- a/internal/controller/ec2.aws/securitygroup_controller.go
+++ b/internal/controller/ec2.aws/securitygroup_controller.go
@@ -70,8 +70,8 @@ const (
 	AnnotationKeyReconciliationPaused = "crossplane.io/paused"
 )
 
-func getFinalizerName(sgId string) string {
-	return securityGroupFinalizer + "/" + sgId
+func getFinalizerName(sgID string) string {
+	return securityGroupFinalizer + "/" + sgID
 }
 
 // SecurityGroupReconciler reconciles a SecurityGroup object
@@ -572,8 +572,8 @@ func (r *SecurityGroupReconciliation) reconcileDelete(ctx context.Context, sg *s
 				r.log.Error(err, fmt.Sprintf("failed to detach sg %v from kmp %v at %v", r.sg.Name, key.Name, key.Namespace))
 				continue
 			}
-			if controllerutil.ContainsFinalizer(&kmp, getFinalizerName(string(r.sg.UID))) {
-				r.removeKMPFinalizer(ctx, kmp)
+			if controllerutil.ContainsFinalizer(&kmp, getFinalizerName(csg.Status.AtProvider.SecurityGroupID)) {
+				r.removeKMPFinalizer(ctx, csg, kmp)
 			}
 		case "KopsControlPlane":
 			kcp := kcontrolplanev1alpha1.KopsControlPlane{}
@@ -604,7 +604,7 @@ func (r *SecurityGroupReconciliation) reconcileDelete(ctx context.Context, sg *s
 				r.log.Error(err, fmt.Sprintf("failed to detach sg %v from kmps of %v", r.sg.Name, kcp.Name))
 			}
 
-			r.removeKCPFinalizer(ctx, kcp, kmps...)
+			r.removeKCPFinalizer(ctx, kcp, csg, kmps...)
 		default:
 			return resultError, fmt.Errorf("infrastructureRef not supported")
 		}
@@ -843,8 +843,8 @@ func (r *SecurityGroupReconciliation) ensureAttachReferences(ctx context.Context
 				}
 				return resultError, err
 			}
-			if !controllerutil.ContainsFinalizer(&kmp, getFinalizerName(string(r.sg.UID))) {
-				r.addKMPFinalizer(ctx, kmp)
+			if !controllerutil.ContainsFinalizer(&kmp, getFinalizerName(csg.Status.AtProvider.SecurityGroupID)) {
+				r.addKMPFinalizer(ctx, csg, kmp)
 			}
 		case "KopsControlPlane":
 			kcp := kcontrolplanev1alpha1.KopsControlPlane{}
@@ -867,8 +867,8 @@ func (r *SecurityGroupReconciliation) ensureAttachReferences(ctx context.Context
 				}
 				return resultError, err
 			}
-			if !controllerutil.ContainsFinalizer(&kcp, getFinalizerName(string(r.sg.UID))) {
-				r.addKCPFinalizer(ctx, kcp, kmps...)
+			if !controllerutil.ContainsFinalizer(&kcp, getFinalizerName(csg.Status.AtProvider.SecurityGroupID)) {
+				r.addKCPFinalizer(ctx, kcp, csg, kmps...)
 			}
 		default:
 			return resultError, fmt.Errorf("infrastructureRef not supported")
@@ -900,7 +900,7 @@ func (r *SecurityGroupReconciliation) ensureDetachRemovedReferences(ctx context.
 				if err != nil {
 					return resultError, err
 				}
-				r.removeKMPFinalizer(ctx, kmp)
+				r.removeKMPFinalizer(ctx, csg, kmp)
 			case "KopsControlPlane":
 				kcp := kcontrolplanev1alpha1.KopsControlPlane{}
 				key := client.ObjectKey{
@@ -920,7 +920,7 @@ func (r *SecurityGroupReconciliation) ensureDetachRemovedReferences(ctx context.
 				if err != nil {
 					return resultError, err
 				}
-				r.removeKCPFinalizer(ctx, kcp, kmps...)
+				r.removeKCPFinalizer(ctx, kcp, csg, kmps...)
 			default:
 				continue
 			}
@@ -929,41 +929,41 @@ func (r *SecurityGroupReconciliation) ensureDetachRemovedReferences(ctx context.
 	return resultDefault, nil
 }
 
-func (r *SecurityGroupReconciliation) removeKMPFinalizer(ctx context.Context, kmp kinfrastructurev1alpha1.KopsMachinePool) {
-	controllerutil.RemoveFinalizer(&kmp, getFinalizerName(string(r.sg.UID)))
+func (r *SecurityGroupReconciliation) removeKMPFinalizer(ctx context.Context, csg *crossec2v1beta1.SecurityGroup, kmp kinfrastructurev1alpha1.KopsMachinePool) {
+	controllerutil.RemoveFinalizer(&kmp, getFinalizerName(csg.Status.AtProvider.SecurityGroupID))
 	if err := r.Update(ctx, &kmp); err != nil {
 		r.Recorder.Eventf(r.sg, corev1.EventTypeWarning, "FailedToUpdate", "failed to remove finalizer in %s: %s", kmp.Name, err)
 	}
 }
 
-func (r *SecurityGroupReconciliation) removeKCPFinalizer(ctx context.Context, kcp kcontrolplanev1alpha1.KopsControlPlane, kmps ...kinfrastructurev1alpha1.KopsMachinePool) {
-	controllerutil.RemoveFinalizer(&kcp, getFinalizerName(string(r.sg.UID)))
+func (r *SecurityGroupReconciliation) removeKCPFinalizer(ctx context.Context, kcp kcontrolplanev1alpha1.KopsControlPlane, csg *crossec2v1beta1.SecurityGroup, kmps ...kinfrastructurev1alpha1.KopsMachinePool) {
+	controllerutil.RemoveFinalizer(&kcp, getFinalizerName(csg.Status.AtProvider.SecurityGroupID))
 	if err := r.Update(ctx, &kcp); err != nil {
 		r.Recorder.Eventf(r.sg, corev1.EventTypeWarning, "FailedToUpdate", "failed to remove finalizer in %s: %s", kcp.Name, err)
 	}
 	for _, kmp := range kmps {
-		if controllerutil.ContainsFinalizer(&kmp, getFinalizerName(string(r.sg.UID))) {
-			r.removeKMPFinalizer(ctx, kmp)
+		if controllerutil.ContainsFinalizer(&kmp, getFinalizerName(csg.Status.AtProvider.SecurityGroupID)) {
+			r.removeKMPFinalizer(ctx, csg, kmp)
 		}
 	}
 }
 
-func (r *SecurityGroupReconciliation) addKMPFinalizer(ctx context.Context, kmp kinfrastructurev1alpha1.KopsMachinePool) {
-	controllerutil.AddFinalizer(&kmp, getFinalizerName(string(r.sg.UID)))
+func (r *SecurityGroupReconciliation) addKMPFinalizer(ctx context.Context, csg *crossec2v1beta1.SecurityGroup, kmp kinfrastructurev1alpha1.KopsMachinePool) {
+	controllerutil.AddFinalizer(&kmp, getFinalizerName(csg.Status.AtProvider.SecurityGroupID))
 	if err := r.Update(ctx, &kmp); err != nil {
 		r.Recorder.Eventf(r.sg, corev1.EventTypeWarning, "FailedToUpdate", "failed to add finalizer in %s: %s", kmp.Name, err)
 	}
 }
 
-func (r *SecurityGroupReconciliation) addKCPFinalizer(ctx context.Context, kcp kcontrolplanev1alpha1.KopsControlPlane, kmps ...kinfrastructurev1alpha1.KopsMachinePool) {
-	controllerutil.AddFinalizer(&kcp, getFinalizerName(string(r.sg.UID)))
+func (r *SecurityGroupReconciliation) addKCPFinalizer(ctx context.Context, kcp kcontrolplanev1alpha1.KopsControlPlane, csg *crossec2v1beta1.SecurityGroup, kmps ...kinfrastructurev1alpha1.KopsMachinePool) {
+	controllerutil.AddFinalizer(&kcp, getFinalizerName(csg.Status.AtProvider.SecurityGroupID))
 	if err := r.Update(ctx, &kcp); err != nil {
 		r.Recorder.Eventf(r.sg, corev1.EventTypeWarning, "FailedToUpdate", "failed to add finalizer in %s: %s", kcp.Name, err)
 	}
 
 	for _, kmp := range kmps {
-		if !controllerutil.ContainsFinalizer(&kmp, getFinalizerName(string(r.sg.UID))) {
-			r.addKMPFinalizer(ctx, kmp)
+		if !controllerutil.ContainsFinalizer(&kmp, getFinalizerName(csg.Status.AtProvider.SecurityGroupID)) {
+			r.addKMPFinalizer(ctx, csg, kmp)
 		}
 	}
 }

--- a/internal/controller/ec2.aws/securitygroup_controller_test.go
+++ b/internal/controller/ec2.aws/securitygroup_controller_test.go
@@ -64,7 +64,6 @@ var (
 	sg = &securitygroupv1alpha2.SecurityGroup{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-security-group",
-			UID:  "test-uid",
 		},
 		Spec: securitygroupv1alpha2.SecurityGroupSpec{
 			IngressRules: []securitygroupv1alpha2.IngressRule{
@@ -91,7 +90,6 @@ var (
 	anotherSg = &securitygroupv1alpha2.SecurityGroup{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-another-security-group",
-			UID:  "test-another-uid",
 		},
 		Spec: securitygroupv1alpha2.SecurityGroupSpec{
 			IngressRules: []securitygroupv1alpha2.IngressRule{
@@ -118,7 +116,6 @@ var (
 	sgEmpty = &securitygroupv1alpha2.SecurityGroup{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-security-group",
-			UID:  "test-uid",
 		},
 		Spec: securitygroupv1alpha2.SecurityGroupSpec{
 			IngressRules:      []securitygroupv1alpha2.IngressRule{},
@@ -129,7 +126,6 @@ var (
 	sgKCP = &securitygroupv1alpha2.SecurityGroup{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-security-group",
-			UID:  "test-uid",
 		},
 		Spec: securitygroupv1alpha2.SecurityGroupSpec{
 			IngressRules: []securitygroupv1alpha2.IngressRule{
@@ -156,7 +152,6 @@ var (
 	anotherSgKCP = &securitygroupv1alpha2.SecurityGroup{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-another-security-group",
-			UID:  "test-another-uid",
 		},
 		Spec: securitygroupv1alpha2.SecurityGroupSpec{
 			IngressRules: []securitygroupv1alpha2.IngressRule{
@@ -217,7 +212,7 @@ var (
 				},
 			},
 			AtProvider: crossec2v1beta1.SecurityGroupObservation{
-				SecurityGroupID: "sg-1",
+				SecurityGroupID: "sg-2",
 			},
 		},
 	}
@@ -480,7 +475,7 @@ func TestSecurityGroupReconciler(t *testing.T) {
 					Name:          kcp.ObjectMeta.Name,
 					Namespace:     kcp.ObjectMeta.Namespace,
 					Kind:          "KopsControlPlane",
-					FinalizerName: getFinalizerName(string(sgKCP.ObjectMeta.UID)),
+					FinalizerName: getFinalizerName(csg.Status.AtProvider.SecurityGroupID),
 					Expected:      true,
 				},
 			},
@@ -496,7 +491,7 @@ func TestSecurityGroupReconciler(t *testing.T) {
 					Name:          kmp.ObjectMeta.Name,
 					Namespace:     kmp.ObjectMeta.Namespace,
 					Kind:          "KopsMachinePool",
-					FinalizerName: getFinalizerName(string(sg.ObjectMeta.UID)),
+					FinalizerName: getFinalizerName(csg.Status.AtProvider.SecurityGroupID),
 					Expected:      true,
 				},
 			},
@@ -521,14 +516,14 @@ func TestSecurityGroupReconciler(t *testing.T) {
 					Name:          kcp.ObjectMeta.Name,
 					Namespace:     kcp.ObjectMeta.Namespace,
 					Kind:          "KopsControlPlane",
-					FinalizerName: getFinalizerName(string(sgKCP.ObjectMeta.UID)),
+					FinalizerName: getFinalizerName(csg.Status.AtProvider.SecurityGroupID),
 					Expected:      true,
 				},
 				{
 					Name:          kcp.ObjectMeta.Name,
 					Namespace:     kcp.ObjectMeta.Namespace,
 					Kind:          "KopsControlPlane",
-					FinalizerName: getFinalizerName(string(anotherSgKCP.ObjectMeta.UID)),
+					FinalizerName: getFinalizerName(anotherCsg.Status.AtProvider.SecurityGroupID),
 					Expected:      true,
 				},
 			},
@@ -537,13 +532,13 @@ func TestSecurityGroupReconciler(t *testing.T) {
 			description: "should keep only existing sg finalizers in kmp",
 			k8sObjects: []client.Object{
 				cluster, defaultSecret, csg, anotherCsg, anotherSg, kcp,
-				kmpWithFinalizer("test-kops-machine-pool", "test-cluster", []string{getFinalizerName("test-uid"), getFinalizerName("test-another-uid")}),
+				kmpWithFinalizer("test-kops-machine-pool", "test-cluster",
+					[]string{getFinalizerName(csg.Status.AtProvider.SecurityGroupID), getFinalizerName(anotherCsg.Status.AtProvider.SecurityGroupID)}),
 				&securitygroupv1alpha2.SecurityGroup{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:              "test-security-group",
 						DeletionTimestamp: &metav1.Time{Time: time.Now()},
 						Finalizers:        []string{"securitygroup.wildlife.infrastructure.io"},
-						UID:               "test-uid",
 					},
 					Spec: securitygroupv1alpha2.SecurityGroupSpec{
 						IngressRules: []securitygroupv1alpha2.IngressRule{
@@ -582,14 +577,14 @@ func TestSecurityGroupReconciler(t *testing.T) {
 					Name:          "test-kops-machine-pool",
 					Namespace:     metav1.NamespaceDefault,
 					Kind:          "KopsMachinePool",
-					FinalizerName: getFinalizerName(string(anotherSg.ObjectMeta.UID)),
+					FinalizerName: getFinalizerName(anotherCsg.Status.AtProvider.SecurityGroupID),
 					Expected:      true,
 				},
 				{
 					Name:          "test-kops-machine-pool",
 					Namespace:     metav1.NamespaceDefault,
 					Kind:          "KopsMachinePool",
-					FinalizerName: getFinalizerName("test-uid"),
+					FinalizerName: getFinalizerName(csg.Status.AtProvider.SecurityGroupID),
 					Expected:      false,
 				},
 			},
@@ -598,14 +593,15 @@ func TestSecurityGroupReconciler(t *testing.T) {
 			description: "should keep only existing sg finalizers in kcp and related kmps",
 			k8sObjects: []client.Object{
 				cluster, defaultSecret, csg, anotherCsg, anotherSgKCP,
-				kcpWithFinalizer("test-cluster", []string{getFinalizerName("test-uid"), getFinalizerName("test-another-uid")}),
-				kmpWithFinalizer("test-kops-machine-pool", "test-cluster", []string{getFinalizerName("test-uid"), getFinalizerName("test-another-uid")}),
+				kcpWithFinalizer("test-cluster", []string{getFinalizerName(csg.Status.AtProvider.SecurityGroupID),
+					getFinalizerName(anotherCsg.Status.AtProvider.SecurityGroupID)}),
+				kmpWithFinalizer("test-kops-machine-pool", "test-cluster", []string{getFinalizerName(csg.Status.AtProvider.SecurityGroupID),
+					getFinalizerName(anotherCsg.Status.AtProvider.SecurityGroupID)}),
 				&securitygroupv1alpha2.SecurityGroup{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:              "test-security-group",
 						DeletionTimestamp: &metav1.Time{Time: time.Now()},
 						Finalizers:        []string{"securitygroup.wildlife.infrastructure.io"},
-						UID:               "test-uid",
 					},
 					Spec: securitygroupv1alpha2.SecurityGroupSpec{
 						IngressRules: []securitygroupv1alpha2.IngressRule{
@@ -644,28 +640,28 @@ func TestSecurityGroupReconciler(t *testing.T) {
 					Name:          "test-kops-machine-pool",
 					Namespace:     metav1.NamespaceDefault,
 					Kind:          "KopsMachinePool",
-					FinalizerName: getFinalizerName(string(anotherSgKCP.ObjectMeta.UID)),
+					FinalizerName: getFinalizerName(anotherCsg.Status.AtProvider.SecurityGroupID),
 					Expected:      true,
 				},
 				{
 					Name:          "test-kops-machine-pool",
 					Namespace:     metav1.NamespaceDefault,
 					Kind:          "KopsMachinePool",
-					FinalizerName: getFinalizerName("test-uid"),
+					FinalizerName: getFinalizerName(csg.Status.AtProvider.SecurityGroupID),
 					Expected:      false,
 				},
 				{
 					Name:          "test-cluster",
 					Namespace:     metav1.NamespaceDefault,
 					Kind:          "KopsControlPlane",
-					FinalizerName: getFinalizerName(string(anotherSgKCP.ObjectMeta.UID)),
+					FinalizerName: getFinalizerName(anotherCsg.Status.AtProvider.SecurityGroupID),
 					Expected:      true,
 				},
 				{
 					Name:          "test-cluster",
 					Namespace:     metav1.NamespaceDefault,
 					Kind:          "KopsControlPlane",
-					FinalizerName: getFinalizerName("test-uid"),
+					FinalizerName: getFinalizerName(csg.Status.AtProvider.SecurityGroupID),
 					Expected:      false,
 				},
 			},
@@ -674,7 +670,7 @@ func TestSecurityGroupReconciler(t *testing.T) {
 			description: "should reconcile sg without changes in kmp",
 			k8sObjects: []client.Object{
 				cluster, defaultSecret, csg, sg, kcp,
-				kmpWithFinalizer("test-kops-machine-pool", "test-cluster", []string{getFinalizerName("test-uid")}),
+				kmpWithFinalizer("test-kops-machine-pool", "test-cluster", []string{getFinalizerName(csg.Status.AtProvider.SecurityGroupID)}),
 			},
 			sgsToReconcile: []sgToReconcile{
 				{
@@ -687,7 +683,7 @@ func TestSecurityGroupReconciler(t *testing.T) {
 					Name:          "test-kops-machine-pool",
 					Namespace:     metav1.NamespaceDefault,
 					Kind:          "KopsMachinePool",
-					FinalizerName: getFinalizerName(string(sg.ObjectMeta.UID)),
+					FinalizerName: getFinalizerName(csg.Status.AtProvider.SecurityGroupID),
 					Expected:      true,
 				},
 			},
@@ -696,8 +692,8 @@ func TestSecurityGroupReconciler(t *testing.T) {
 			description: "should reconcile sg without changes in kcp",
 			k8sObjects: []client.Object{
 				cluster, defaultSecret, csg, sgKCP,
-				kcpWithFinalizer("test-cluster", []string{getFinalizerName(string(sgKCP.ObjectMeta.UID))}),
-				kmpWithFinalizer("test-kops-machine-pool", "test-cluster", []string{getFinalizerName(string(sgKCP.ObjectMeta.UID))}),
+				kcpWithFinalizer("test-cluster", []string{getFinalizerName(csg.Status.AtProvider.SecurityGroupID)}),
+				kmpWithFinalizer("test-kops-machine-pool", "test-cluster", []string{getFinalizerName(csg.Status.AtProvider.SecurityGroupID)}),
 			},
 			sgsToReconcile: []sgToReconcile{
 				{
@@ -710,14 +706,14 @@ func TestSecurityGroupReconciler(t *testing.T) {
 					Name:          "test-kops-machine-pool",
 					Namespace:     metav1.NamespaceDefault,
 					Kind:          "KopsMachinePool",
-					FinalizerName: getFinalizerName(string(sgKCP.ObjectMeta.UID)),
+					FinalizerName: getFinalizerName(csg.Status.AtProvider.SecurityGroupID),
 					Expected:      true,
 				},
 				{
 					Name:          "test-cluster",
 					Namespace:     metav1.NamespaceDefault,
 					Kind:          "KopsControlPlane",
-					FinalizerName: getFinalizerName(string(sgKCP.ObjectMeta.UID)),
+					FinalizerName: getFinalizerName(csg.Status.AtProvider.SecurityGroupID),
 					Expected:      true,
 				},
 			},
@@ -741,14 +737,14 @@ func TestSecurityGroupReconciler(t *testing.T) {
 					Name:          kmp.ObjectMeta.Name,
 					Namespace:     kmp.ObjectMeta.Namespace,
 					Kind:          "KopsMachinePool",
-					FinalizerName: getFinalizerName(string(sgKCP.ObjectMeta.UID)),
+					FinalizerName: getFinalizerName("sg-1"),
 					Expected:      false,
 				},
 				{
 					Name:          kcp.ObjectMeta.Name,
 					Namespace:     kcp.ObjectMeta.Namespace,
 					Kind:          "KopsControlPlane",
-					FinalizerName: getFinalizerName(string(sgKCP.ObjectMeta.UID)),
+					FinalizerName: getFinalizerName("sg-1"),
 					Expected:      false,
 				},
 			},
@@ -772,7 +768,7 @@ func TestSecurityGroupReconciler(t *testing.T) {
 					Name:          kmp.ObjectMeta.Name,
 					Namespace:     kmp.ObjectMeta.Namespace,
 					Kind:          "KopsMachinePool",
-					FinalizerName: getFinalizerName(string(sg.ObjectMeta.UID)),
+					FinalizerName: getFinalizerName("sg-1"),
 					Expected:      false,
 				},
 			},
@@ -882,7 +878,6 @@ func TestSecurityGroupReconciler(t *testing.T) {
 				&securitygroupv1alpha2.SecurityGroup{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "test-security-group",
-						UID:  "test-uid",
 					},
 					Spec: securitygroupv1alpha2.SecurityGroupSpec{
 						IngressRules: []securitygroupv1alpha2.IngressRule{
@@ -930,7 +925,7 @@ func TestSecurityGroupReconciler(t *testing.T) {
 							"cluster.x-k8s.io/cluster-name": "test-cluster",
 						},
 						Finalizers: []string{
-							getFinalizerName("test-security-group"),
+							getFinalizerName(csg.Status.AtProvider.SecurityGroupID),
 						},
 					},
 					Spec: kinfrastructurev1alpha1.KopsMachinePoolSpec{
@@ -950,14 +945,14 @@ func TestSecurityGroupReconciler(t *testing.T) {
 					Name:          kmp.ObjectMeta.Name,
 					Namespace:     kmp.ObjectMeta.Namespace,
 					Kind:          "KopsMachinePool",
-					FinalizerName: getFinalizerName("test-uid"),
+					FinalizerName: getFinalizerName(csg.Status.AtProvider.SecurityGroupID),
 					Expected:      true,
 				},
 				{
 					Name:          "test-another-machine-pool",
 					Namespace:     metav1.NamespaceDefault,
 					Kind:          "KopsMachinePool",
-					FinalizerName: getFinalizerName("test-uid"),
+					FinalizerName: getFinalizerName(csg.Status.AtProvider.SecurityGroupID),
 					Expected:      false,
 				},
 			},
@@ -2638,7 +2633,7 @@ func TestReconcileDelete(t *testing.T) {
 			description: "should remove crossplane security group referencing kmp and remove finalizer",
 			k8sObjects: []client.Object{
 				sg, csg, kcp, cluster, defaultSecret,
-				kmpWithFinalizer("test-kops-machine-pool", "test-cluster", []string{getFinalizerName(string(sg.ObjectMeta.UID))}),
+				kmpWithFinalizer("test-kops-machine-pool", "test-cluster", []string{getFinalizerName(csg.Status.AtProvider.SecurityGroupID)}),
 			},
 			sgTarget: sg,
 			FinalizersAt: []*ReferencedPool{
@@ -2646,7 +2641,7 @@ func TestReconcileDelete(t *testing.T) {
 					Name:          "test-kops-machine-pool",
 					Namespace:     metav1.NamespaceDefault,
 					Kind:          "KopsMachinePool",
-					FinalizerName: getFinalizerName(string(sg.ObjectMeta.UID)),
+					FinalizerName: getFinalizerName(csg.Status.AtProvider.SecurityGroupID),
 					Expected:      false,
 				},
 			},
@@ -2676,22 +2671,22 @@ func TestReconcileDelete(t *testing.T) {
 			description: "should remove the crossplane security group referencing kcp and remove finalizer",
 			k8sObjects: []client.Object{
 				sgKCP, csg, cluster, defaultSecret,
-				kmpWithFinalizer("test-kops-machine-pool", "test-cluster", []string{getFinalizerName(string(sgKCP.ObjectMeta.UID))}),
-				kcpWithFinalizer("test-cluster", []string{getFinalizerName(string(sgKCP.ObjectMeta.UID))}),
+				kmpWithFinalizer("test-kops-machine-pool", "test-cluster", []string{getFinalizerName(csg.Status.AtProvider.SecurityGroupID)}),
+				kcpWithFinalizer("test-cluster", []string{getFinalizerName(csg.Status.AtProvider.SecurityGroupID)}),
 			},
 			FinalizersAt: []*ReferencedPool{
 				{
 					Name:          "test-cluster",
 					Namespace:     metav1.NamespaceDefault,
 					Kind:          "KopsControlPlane",
-					FinalizerName: getFinalizerName(string(sgKCP.ObjectMeta.UID)),
+					FinalizerName: getFinalizerName(csg.Status.AtProvider.SecurityGroupID),
 					Expected:      false,
 				},
 				{
 					Name:          "test-kops-machine-pool",
 					Namespace:     metav1.NamespaceDefault,
 					Kind:          "KopsMachinePool",
-					FinalizerName: getFinalizerName(string(sgKCP.ObjectMeta.UID)),
+					FinalizerName: getFinalizerName(csg.Status.AtProvider.SecurityGroupID),
 					Expected:      false,
 				},
 			},
@@ -3399,6 +3394,7 @@ func TestEnsureAttachReferences(t *testing.T) {
 				defaultSecret,
 				kmp,
 				kcp,
+				csg,
 				&kinfrastructurev1alpha1.KopsMachinePool{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: metav1.NamespaceDefault,
@@ -3407,7 +3403,7 @@ func TestEnsureAttachReferences(t *testing.T) {
 							"cluster.x-k8s.io/cluster-name": "test-cluster",
 						},
 						Finalizers: []string{
-							getFinalizerName("test-uid"),
+							getFinalizerName(csg.Status.AtProvider.SecurityGroupID),
 						},
 					},
 					Spec: kinfrastructurev1alpha1.KopsMachinePoolSpec{
@@ -3424,7 +3420,6 @@ func TestEnsureAttachReferences(t *testing.T) {
 			sg: &securitygroupv1alpha2.SecurityGroup{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-security-group",
-					UID:  "test-uid",
 				},
 				Spec: securitygroupv1alpha2.SecurityGroupSpec{
 					IngressRules: []securitygroupv1alpha2.IngressRule{
@@ -3470,14 +3465,14 @@ func TestEnsureAttachReferences(t *testing.T) {
 					Name:          kmp.ObjectMeta.Name,
 					Namespace:     kmp.ObjectMeta.Namespace,
 					Kind:          "KopsMachinePool",
-					FinalizerName: getFinalizerName("test-uid"),
+					FinalizerName: getFinalizerName(csg.Status.AtProvider.SecurityGroupID),
 					Expected:      true,
 				},
 				{
 					Name:          "test-another-kops-machine-pool",
 					Namespace:     metav1.NamespaceDefault,
 					Kind:          "KopsMachinePool",
-					FinalizerName: getFinalizerName("test-uid"),
+					FinalizerName: getFinalizerName(csg.Status.AtProvider.SecurityGroupID),
 					Expected:      true,
 				},
 			},
@@ -3485,14 +3480,13 @@ func TestEnsureAttachReferences(t *testing.T) {
 		{
 			description: "should attach sg to kcp and to related kmps and attach sg to one single kmp but not to his kcp",
 			k8sObjects: []client.Object{
-				defaultSecret, kmp, kcp,
-				kmpWithFinalizer("test-another-kops-machine-pool", "test-cluster-2", []string{"test-security-group"}),
+				defaultSecret, kmp, kcp, csg,
+				kmpWithFinalizer("test-another-kops-machine-pool", "test-cluster-2", []string{getFinalizerName(csg.Status.AtProvider.SecurityGroupID)}),
 				kcpWithFinalizer("test-cluster-2", []string{}),
 			},
 			sg: &securitygroupv1alpha2.SecurityGroup{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-security-group",
-					UID:  "test-uid",
 				},
 				Spec: securitygroupv1alpha2.SecurityGroupSpec{
 					IngressRules: []securitygroupv1alpha2.IngressRule{
@@ -3538,28 +3532,28 @@ func TestEnsureAttachReferences(t *testing.T) {
 					Name:          kmp.ObjectMeta.Name,
 					Namespace:     kmp.ObjectMeta.Namespace,
 					Kind:          "KopsMachinePool",
-					FinalizerName: getFinalizerName("test-uid"),
+					FinalizerName: getFinalizerName(csg.Status.AtProvider.SecurityGroupID),
 					Expected:      true,
 				},
 				{
 					Name:          "test-cluster",
 					Namespace:     metav1.NamespaceDefault,
 					Kind:          "KopsControlPlane",
-					FinalizerName: getFinalizerName("test-uid"),
+					FinalizerName: getFinalizerName(csg.Status.AtProvider.SecurityGroupID),
 					Expected:      true,
 				},
 				{
 					Name:          "test-another-kops-machine-pool",
 					Namespace:     metav1.NamespaceDefault,
 					Kind:          "KopsMachinePool",
-					FinalizerName: getFinalizerName("test-uid"),
+					FinalizerName: getFinalizerName(csg.Status.AtProvider.SecurityGroupID),
 					Expected:      true,
 				},
 				{
 					Name:          "test-cluster-2",
 					Namespace:     metav1.NamespaceDefault,
 					Kind:          "KopsControlPlane",
-					FinalizerName: getFinalizerName("test-uid"),
+					FinalizerName: getFinalizerName(csg.Status.AtProvider.SecurityGroupID),
 					Expected:      false,
 				},
 			},
@@ -3711,6 +3705,7 @@ func TestEnsureDetachRemovedReferences(t *testing.T) {
 			description: "should detach sg from kmp",
 			k8sObjects: []client.Object{
 				defaultSecret,
+				csg,
 				&kinfrastructurev1alpha1.KopsMachinePool{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: metav1.NamespaceDefault,
@@ -3719,7 +3714,7 @@ func TestEnsureDetachRemovedReferences(t *testing.T) {
 							"cluster.x-k8s.io/cluster-name": "test-cluster",
 						},
 						Finalizers: []string{
-							getFinalizerName("test-uid"),
+							getFinalizerName(csg.Status.AtProvider.SecurityGroupID),
 						},
 					},
 					Spec: kinfrastructurev1alpha1.KopsMachinePoolSpec{
@@ -3740,7 +3735,7 @@ func TestEnsureDetachRemovedReferences(t *testing.T) {
 							"cluster.x-k8s.io/cluster-name": "test-cluster",
 						},
 						Finalizers: []string{
-							getFinalizerName("test-uid"),
+							getFinalizerName(csg.Status.AtProvider.SecurityGroupID),
 						},
 					},
 					Spec: kinfrastructurev1alpha1.KopsMachinePoolSpec{
@@ -3757,7 +3752,6 @@ func TestEnsureDetachRemovedReferences(t *testing.T) {
 			sg: &securitygroupv1alpha2.SecurityGroup{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-security-group",
-					UID:  "test-uid",
 				},
 				Spec: securitygroupv1alpha2.SecurityGroupSpec{
 					IngressRules: []securitygroupv1alpha2.IngressRule{
@@ -3803,14 +3797,14 @@ func TestEnsureDetachRemovedReferences(t *testing.T) {
 					Name:          kmp.ObjectMeta.Name,
 					Namespace:     kmp.ObjectMeta.Namespace,
 					Kind:          "KopsMachinePool",
-					FinalizerName: getFinalizerName("test-uid"),
+					FinalizerName: getFinalizerName(csg.Status.AtProvider.SecurityGroupID),
 					Expected:      true,
 				},
 				{
 					Name:          "test-another-machine-pool",
 					Namespace:     metav1.NamespaceDefault,
 					Kind:          "KopsMachinePool",
-					FinalizerName: getFinalizerName("test-uid"),
+					FinalizerName: getFinalizerName(csg.Status.AtProvider.SecurityGroupID),
 					Expected:      false,
 				},
 			},
@@ -3818,14 +3812,13 @@ func TestEnsureDetachRemovedReferences(t *testing.T) {
 		{
 			description: "should detach sg from kcp",
 			k8sObjects: []client.Object{
-				defaultSecret, kcp,
-				kmpWithFinalizer("test-kops-machine-pool", "test-cluster", []string{getFinalizerName("test-uid")}),
-				kcpWithFinalizer("test-cluster-2", []string{getFinalizerName("test-uid")}),
+				defaultSecret, kcp, csg,
+				kmpWithFinalizer("test-kops-machine-pool", "test-cluster", []string{getFinalizerName(csg.Status.AtProvider.SecurityGroupID)}),
+				kcpWithFinalizer("test-cluster-2", []string{getFinalizerName(csg.Status.AtProvider.SecurityGroupID)}),
 			},
 			sg: &securitygroupv1alpha2.SecurityGroup{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-security-group",
-					UID:  "test-uid",
 				},
 				Spec: securitygroupv1alpha2.SecurityGroupSpec{
 					IngressRules: []securitygroupv1alpha2.IngressRule{
@@ -3871,14 +3864,14 @@ func TestEnsureDetachRemovedReferences(t *testing.T) {
 					Name:          kmp.ObjectMeta.Name,
 					Namespace:     kmp.ObjectMeta.Namespace,
 					Kind:          "KopsMachinePool",
-					FinalizerName: getFinalizerName("test-uid"),
+					FinalizerName: getFinalizerName(csg.Status.AtProvider.SecurityGroupID),
 					Expected:      true,
 				},
 				{
 					Name:          "test-cluster-2",
 					Namespace:     metav1.NamespaceDefault,
 					Kind:          "KopsControlPlane",
-					FinalizerName: getFinalizerName("test-uid"),
+					FinalizerName: getFinalizerName(csg.Status.AtProvider.SecurityGroupID),
 					Expected:      false,
 				},
 			},
@@ -3886,14 +3879,13 @@ func TestEnsureDetachRemovedReferences(t *testing.T) {
 		{
 			description: "should detach sg from both kcp and kmp ",
 			k8sObjects: []client.Object{
-				defaultSecret, kcp,
-				kmpWithFinalizer("test-kops-machine-pool", "test-cluster", []string{getFinalizerName("test-uid")}),
-				kcpWithFinalizer("test-cluster-2", []string{getFinalizerName("test-uid")}),
+				defaultSecret, kcp, csg,
+				kmpWithFinalizer("test-kops-machine-pool", "test-cluster", []string{getFinalizerName(csg.Status.AtProvider.SecurityGroupID)}),
+				kcpWithFinalizer("test-cluster-2", []string{getFinalizerName(csg.Status.AtProvider.SecurityGroupID)}),
 			},
 			sg: &securitygroupv1alpha2.SecurityGroup{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-security-group",
-					UID:  "test-uid",
 				},
 				Spec: securitygroupv1alpha2.SecurityGroupSpec{
 					IngressRules: []securitygroupv1alpha2.IngressRule{
@@ -3932,14 +3924,14 @@ func TestEnsureDetachRemovedReferences(t *testing.T) {
 					Name:          kmp.ObjectMeta.Name,
 					Namespace:     kmp.ObjectMeta.Namespace,
 					Kind:          "KopsMachinePool",
-					FinalizerName: getFinalizerName("test-uid"),
+					FinalizerName: getFinalizerName(csg.Status.AtProvider.SecurityGroupID),
 					Expected:      false,
 				},
 				{
 					Name:          "test-cluster-2",
 					Namespace:     metav1.NamespaceDefault,
 					Kind:          "KopsControlPlane",
-					FinalizerName: getFinalizerName("test-uid"),
+					FinalizerName: getFinalizerName(csg.Status.AtProvider.SecurityGroupID),
 					Expected:      false,
 				},
 			},
@@ -3947,14 +3939,13 @@ func TestEnsureDetachRemovedReferences(t *testing.T) {
 		{
 			description: "should not detach anything",
 			k8sObjects: []client.Object{
-				defaultSecret, kcp,
-				kmpWithFinalizer("test-kops-machine-pool", "test-cluster", []string{getFinalizerName("test-uid")}),
-				kcpWithFinalizer("test-cluster-2", []string{getFinalizerName("test-uid")}),
+				defaultSecret, kcp, csg,
+				kmpWithFinalizer("test-kops-machine-pool", "test-cluster", []string{getFinalizerName(csg.Status.AtProvider.SecurityGroupID)}),
+				kcpWithFinalizer("test-cluster-2", []string{getFinalizerName(csg.Status.AtProvider.SecurityGroupID)}),
 			},
 			sg: &securitygroupv1alpha2.SecurityGroup{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-security-group",
-					UID:  "test-uid",
 				},
 				Spec: securitygroupv1alpha2.SecurityGroupSpec{
 					IngressRules: []securitygroupv1alpha2.IngressRule{
@@ -4006,14 +3997,14 @@ func TestEnsureDetachRemovedReferences(t *testing.T) {
 					Name:          kmp.ObjectMeta.Name,
 					Namespace:     kmp.ObjectMeta.Namespace,
 					Kind:          "KopsMachinePool",
-					FinalizerName: getFinalizerName("test-uid"),
+					FinalizerName: getFinalizerName(csg.Status.AtProvider.SecurityGroupID),
 					Expected:      true,
 				},
 				{
 					Name:          "test-cluster-2",
 					Namespace:     metav1.NamespaceDefault,
 					Kind:          "KopsControlPlane",
-					FinalizerName: getFinalizerName("test-uid"),
+					FinalizerName: getFinalizerName(csg.Status.AtProvider.SecurityGroupID),
 					Expected:      true,
 				},
 			},


### PR DESCRIPTION

We need these changes because our controller throws reconciler errors when our sgName is bigger than 63 characters. So we decided to change the finalizer suffix from sgName to sgID because it is smaller and still references which security group put that finalizer.
 
`failed to add finalizer in xxxxx-xxxxxx: KopsMachinePool.infrastructure.cluster.x-k8s.io "xxxxxx-xxxxxx" is invalid: metadata.finalizers: Invalid value: "securitygroup.wildlife.infrastructure.io/xxxxxxxxxxxxx-xxxxxxxxxxxxx-xxxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx': name part must be no more than 63 characters`