### PR TITLE
chore: update tag name of custom metrics

### DIFF
--- a/.kubernetes/manifests.yaml
+++ b/.kubernetes/manifests.yaml
@@ -325,7 +325,7 @@ spec:
               key: account
               name: spotinst-credentials
               optional: true
-        image: tfgco/kubernetes-crossplane-infrastructure-operator:v0.8.4-alpha
+        image: tfgco/kubernetes-crossplane-infrastructure-operator:v0.8.5-alpha
         livenessProbe:
           httpGet:
             path: /healthz

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: tfgco/kubernetes-crossplane-infrastructure-operator
-  newTag: v0.8.4-alpha
+  newTag: v0.8.5-alpha

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -13,7 +13,7 @@ var (
 		prometheus.GaugeOpts{
 			Name: "custom_reconciliation_consecutive_errors_total",
 			Help: "Total number of consecutive reconciliation errors labeled by controller, name of securityGroup/clustermesh and cluster environment",
-		}, []string{"controller", "object_name", "cluster_environment"},
+		}, []string{"controller", "object_name", "object_environment"},
 	)
 )
 


### PR DESCRIPTION
The PR is to change the tag name cluster_environment to object_environment to match the other tag object_name. 