### PR TITLE
refactor: update karpenter tag that is used by the selector

### DIFF
--- a/pkg/crossplane/crossplane.go
+++ b/pkg/crossplane/crossplane.go
@@ -395,8 +395,8 @@ func getTagsFromInfrastructureRefs(ctx context.Context, kubeClient client.Client
 		switch infraRef.Kind {
 		case "KopsMachinePool":
 			tags = append(tags, crossec2v1beta1.Tag{
-				Key:   "karpenter/owner",
-				Value: fmt.Sprintf("%s/%s", clusterName, infraRef.Name),
+				Key:   fmt.Sprintf("karpenter/%s/%s", clusterName, infraRef.Name),
+				Value: "true",
 			})
 		case "KopsControlPlane":
 			kmps, err := kops.GetKopsMachinePoolsWithLabel(ctx, kubeClient, "cluster.x-k8s.io/cluster-name", clusterName)
@@ -406,8 +406,8 @@ func getTagsFromInfrastructureRefs(ctx context.Context, kubeClient client.Client
 
 			for _, kmp := range kmps {
 				tags = append(tags, crossec2v1beta1.Tag{
-					Key:   "karpenter/owner",
-					Value: fmt.Sprintf("%s/%s", clusterName, kmp.Name),
+					Key:   fmt.Sprintf("karpenter/%s/%s", clusterName, kmp.Name),
+					Value: "true",
 				})
 			}
 		}

--- a/pkg/crossplane/crossplane_test.go
+++ b/pkg/crossplane/crossplane_test.go
@@ -1494,8 +1494,8 @@ func TestCreateOrUpdateCrossplaneSecurityGroup(t *testing.T) {
 						Value: "kubernetes-crossplane-infrastructure-operator",
 					},
 					{
-						Key:   "karpenter/owner",
-						Value: "testCluster/testIG",
+						Key:   "karpenter/testCluster/testIG",
+						Value: "true",
 					},
 				}
 
@@ -1597,12 +1597,12 @@ func TestCreateOrUpdateCrossplaneSecurityGroup(t *testing.T) {
 						Value: "kubernetes-crossplane-infrastructure-operator",
 					},
 					{
-						Key:   "karpenter/owner",
-						Value: "testCluster/testIGA",
+						Key:   "karpenter/testCluster/testIGA",
+						Value: "true",
 					},
 					{
-						Key:   "karpenter/owner",
-						Value: "testCluster/testIGB",
+						Key:   "karpenter/testCluster/testIGB",
+						Value: "true",
 					},
 				}
 


### PR DESCRIPTION
The goal of this PR is to update the tag being used by karpenter in the Security Groups